### PR TITLE
fix: crashing on iPhone

### DIFF
--- a/src/hooks/use-core.js
+++ b/src/hooks/use-core.js
@@ -17,7 +17,7 @@ const useCore = ({ flags }) => {
     element.style.overflow = 'hidden';
     const picasso = configurePicasso();
     const picassoInstance = picasso({
-      renderer: { prio: [options.renderer || 'svg'] },
+      renderer: { prio: [options.renderer || 'canvas'] },
     });
 
     const chart = picassoInstance.chart({


### PR DESCRIPTION
## Description
Kudos to @tasseKATT , who discovered the root cause.
SVG renderer generates new DOMs, which are not recycled well on Safari, causing the crash.
The fix is to change it to `canvas`

### Verification
Manually on iPhone 12 connected to Mac. The issue is resolved.