### PR TITLE
fix: avoid fetching data if panning is in progress

### DIFF
--- a/nebula.config.js
+++ b/nebula.config.js
@@ -29,6 +29,7 @@ module.exports = {
     renderConfigs,
     flags: {
       panZoom: true,
+      DATA_BINNING: true,
     },
   },
 };

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -27,6 +27,7 @@ describe('chart-model', () => {
     ];
     viewHandler = {
       getMeta: sandbox.stub().returns('isHomeState'),
+      getInteractionInProgress: sandbox.stub(),
     };
     dataHandler = {
       getMeta: sandbox.stub().returns({ isBinnedData: false }),
@@ -228,6 +229,15 @@ describe('chart-model', () => {
             excludeFromUpdate: ['x-axis-title', 'y-axis-title'],
           })
         ).to.have.been.calledOnce;
+      });
+    });
+
+    describe('handle dataview update', () => {
+      it('should not fetch data if interaction is in progress', () => {
+        viewHandler.getInteractionInProgress.returns(true);
+        create();
+        viewState.dataView();
+        expect(dataHandler.getMeta).to.not.have.been.called;
       });
     });
   });

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -235,9 +235,10 @@ describe('chart-model', () => {
     describe('handle dataview update', () => {
       it('should not fetch data if interaction is in progress', () => {
         viewHandler.getInteractionInProgress.returns(true);
+        dataHandler.fetch = sandbox.stub();
         create();
         viewState.dataView();
-        expect(dataHandler.getMeta).to.not.have.been.called;
+        expect(dataHandler.fetch).to.not.have.been.called;
       });
     });
   });

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -115,6 +115,10 @@ export default function createChartModel({
   };
 
   const handleDataViewUpdate = () => {
+    if (viewHandler.getInteractionInProgress()) {
+      updatePartial();
+      return;
+    }
     const binnedBeforeFetch = dataHandler.getMeta().isBinnedData;
     dataHandler
       .fetch()


### PR DESCRIPTION
## Summary

We can postpone fetching data during panning. This will increase performance and prevent legend from switching back and forth between binned and normal data. It also avoids showing two types of data simultaneously on the chart (see video 1).

### Verification

Current: 

https://user-images.githubusercontent.com/70384379/142886214-d5c8be1b-68c1-4aba-85ad-7a8ead1c16d2.mov

After fix:

https://user-images.githubusercontent.com/70384379/142886264-3b6ec532-db6a-4e72-9ca5-e39f91528ef8.mov



