### PR TITLE
fix: fix label order

### DIFF
--- a/src/picasso-components/point-label/index.js
+++ b/src/picasso-components/point-label/index.js
@@ -41,7 +41,7 @@ export default {
     }
 
     const nodeFilter = (node) => node.key === key && showLabel(node);
-    const nodes = [...this.chart.findShapes('circle'), ...this.chart.findShapes('path')].filter(nodeFilter);
+    const nodes = [...this.chart.findShapes('circle'), ...this.chart.findShapes('path')].filter(nodeFilter).reverse();
 
     if (!nodes.length) {
       return [];


### PR DESCRIPTION
To fix https://github.com/qlik-oss/sn-scatter-plot/issues/125.
The bubbles rendered later will be on top of the bubbles rendered before.
So the label should based on this order.