### PR TITLE
fix: label and range highlighting issue

### DIFF
--- a/src/picasso-definition/components/heat-map/__tests__/index.spec.js
+++ b/src/picasso-definition/components/heat-map/__tests__/index.spec.js
@@ -125,8 +125,8 @@ describe('heat-map', () => {
           const comp = create();
           const size = { width: 400, height: 200 };
           comp.beforeRender({ size });
-          expect(comp.settings.shape().width).to.equal(10.5);
-          expect(comp.settings.shape().height).to.equal(20.5);
+          expect(comp.settings.shape().width).to.equal(10);
+          expect(comp.settings.shape().height).to.equal(20);
         });
       });
     });

--- a/src/picasso-definition/components/heat-map/index.js
+++ b/src/picasso-definition/components/heat-map/index.js
@@ -54,8 +54,8 @@ export default function createHeatMap(chartModel) {
         const binWidth = Math.abs(firstBin.qText[0] - firstBin.qText[2]);
         const binHeight = Math.abs(firstBin.qText[1] - firstBin.qText[3]);
 
-        binWidthPx = (binWidth * size.width) / (dataView.xAxisMax - dataView.xAxisMin) + 0.5;
-        binHeightPx = (binHeight * size.height) / (dataView.yAxisMax - dataView.yAxisMin) + 0.5;
+        binWidthPx = (binWidth * size.width) / (dataView.xAxisMax - dataView.xAxisMin);
+        binHeightPx = (binHeight * size.height) / (dataView.yAxisMax - dataView.yAxisMin);
       }
     },
     rendererSettings: {


### PR DESCRIPTION
Remove adding 0.5 to the width and height of a bin. 

With 0.5, it can remove the white gaps between each bins, but will causing sometime labels not showing(not enough space) or bins range selection has weird colors. So will remove adding 0.5.

Fixing:
![Screenshot 2022-01-20 at 10 07 56](https://user-images.githubusercontent.com/25456307/150319166-44cb4031-5adf-4556-9634-9f5710a42910.png)

