### PR TITLE
fix: pinch issue between bin and normal

### DIFF
--- a/src/picasso-definition/interactions/__tests__/pan.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pan.spec.js
@@ -63,6 +63,12 @@ describe('pan', () => {
         expect(panObject.options.enable('', 'e')).to.equal(false);
       });
 
+      it('should return false if has no corresponding component ', () => {
+        actions.zoom.enabled.returns(true);
+        chart.componentsFromPoint.withArgs({ x: 200, y: 100 }).returns([]);
+        expect(panObject.options.enable('', { center: { x: 200, y: 100 } })).to.equal(false);
+      });
+
       it('should return true if has corresponding component ', () => {
         actions.zoom.enabled.returns(true);
         chart.componentsFromPoint
@@ -98,6 +104,21 @@ describe('pan', () => {
     });
 
     describe('areaPanmove', () => {
+      it('should not modify myDataView if pan is not started', () => {
+        e = { preventDefault: sandbox.stub(), deltaX: 10, deltaY: 20 };
+        panObject.events.areaPan = {
+          componentSize: { width: 100, height: 200 },
+          xAxisMin: -1000,
+          xAxisMax: 1000,
+          yAxisMin: 0,
+          yAxisMax: 2000,
+          miniChart: { panInMiniChart: false, navWindowScale: 0.05 },
+        };
+        myDataView = {};
+        panObject.events.areaPanmove(e);
+        expect(myDataView).to.deep.equal({});
+      });
+
       it('should modify myDataView correctly', () => {
         e = { preventDefault: sandbox.stub(), deltaX: 10, deltaY: 20 };
         panObject.events.areaPanstart(e);
@@ -180,6 +201,22 @@ describe('pan', () => {
     });
 
     describe('areaPanend', () => {
+      it('should not update dataview and set events.started if pan is not started', () => {
+        e = { preventDefault: sandbox.stub() };
+        panObject.events.areaPan = {
+          componentSize: { width: 100, height: 200 },
+          xAxisMin: -1000,
+          xAxisMax: 1000,
+          yAxisMin: 0,
+          yAxisMax: 2000,
+          miniChart: { panInMiniChart: false, navWindowScale: 0.05 },
+        };
+        myDataView = {};
+        panObject.events.areaPanend(e);
+        expect(myDataView).to.deep.equal({});
+        expect(panObject.events.started).to.equal(undefined);
+      });
+
       it('should set events.started to false', () => {
         e = { preventDefault: sandbox.stub() };
         panObject.events.areaPanstart(e);

--- a/src/picasso-definition/interactions/__tests__/pan.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pan.spec.js
@@ -63,12 +63,12 @@ describe('pan', () => {
         expect(panObject.options.enable('', 'e')).to.equal(false);
       });
 
-      it('should return correct pointAreaPanned', () => {
+      it('should return true if has corresponding component ', () => {
         actions.zoom.enabled.returns(true);
         chart.componentsFromPoint
           .withArgs({ x: 200, y: 100 })
           .returns([{ key: 'point-comp' }, { key: 'point-comp', id: 'should-not-return-this' }]);
-        expect(panObject.options.enable('', { center: { x: 200, y: 100 } })).to.deep.equal({ key: 'point-comp' });
+        expect(panObject.options.enable('', { center: { x: 200, y: 100 } })).to.equal(true);
       });
     });
   });
@@ -81,7 +81,7 @@ describe('pan', () => {
     describe('areaPanstart', () => {
       it('should add correct areaPan object to events, case 1: tap is inside the mini chart', () => {
         viewHandler.getDataView.returns({ xAxisMin: 1, xAxisMax: 2, yAxisMin: 3, yAxisMax: 4 });
-        panObject.events.pointAreaPanned = { rect: { width: 1, height: 2 } };
+        panObject.events.componentSize = { width: 1, height: 2 };
         e = { preventDefault: sandbox.stub() };
         panObject.events.areaPanstart(e);
         expect(panObject.events.started).to.equal('areaPan');
@@ -100,6 +100,7 @@ describe('pan', () => {
     describe('areaPanmove', () => {
       it('should modify myDataView correctly', () => {
         e = { preventDefault: sandbox.stub(), deltaX: 10, deltaY: 20 };
+        panObject.events.areaPanstart(e);
         panObject.events.areaPan = {
           componentSize: { width: 100, height: 200 },
           xAxisMin: -1000,
@@ -125,6 +126,7 @@ describe('pan', () => {
 
       it('should modify myDataView correctly when panning inside mini chart', () => {
         e = { preventDefault: sandbox.stub(), deltaX: 10, deltaY: 20 };
+        panObject.events.areaPanstart(e);
         panObject.events.areaPan = {
           componentSize: { width: 100, height: 200 },
           xAxisMin: -1000,
@@ -152,6 +154,7 @@ describe('pan', () => {
         rtl = true;
         e = { preventDefault: sandbox.stub(), deltaX: 10, deltaY: 20 };
         panObject = pan({ chart, actions, viewHandler, rtl });
+        panObject.events.areaPanstart(e);
         panObject.events.areaPan = {
           componentSize: { width: 100, height: 200 },
           xAxisMin: -1000,
@@ -179,6 +182,7 @@ describe('pan', () => {
     describe('areaPanend', () => {
       it('should set events.started to false', () => {
         e = { preventDefault: sandbox.stub() };
+        panObject.events.areaPanstart(e);
         panObject.events.areaPan = {
           componentSize: { width: 100, height: 200 },
           xAxisMin: -1000,

--- a/src/picasso-definition/interactions/__tests__/pinch.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pinch.spec.js
@@ -49,6 +49,12 @@ describe('pinch', () => {
         expect(pinchObject.options.enable('', 'e')).to.equal(false);
       });
 
+      it('should return false if has no corresponding component', () => {
+        actions.zoom.enabled.returns(true);
+        chart.componentsFromPoint.withArgs({ x: 200, y: 100 }).returns([]);
+        expect(pinchObject.options.enable('', { center: { x: 200, y: 100 } })).to.equal(false);
+      });
+
       it('should return true if has corresponding component', () => {
         actions.zoom.enabled.returns(true);
         chart.componentsFromPoint

--- a/src/picasso-definition/interactions/__tests__/pinch.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pinch.spec.js
@@ -49,14 +49,12 @@ describe('pinch', () => {
         expect(pinchObject.options.enable('', 'e')).to.equal(false);
       });
 
-      it('should return correct pointAreaPinched', () => {
+      it('should return true if has corresponding component', () => {
         actions.zoom.enabled.returns(true);
         chart.componentsFromPoint
           .withArgs({ x: 200, y: 100 })
           .returns([{ key: 'point-component' }, { key: 'point-component', id: 'should-not-return-this' }]);
-        expect(pinchObject.options.enable('', { center: { x: 200, y: 100 } })).to.deep.equal({
-          key: 'point-component',
-        });
+        expect(pinchObject.options.enable('', { center: { x: 200, y: 100 } })).to.equal(true);
       });
     });
   });
@@ -69,7 +67,7 @@ describe('pinch', () => {
     describe('zoomstart', () => {
       it('should add correct zoom object to events', () => {
         viewHandler.getDataView.returns({ xAxisMin: 1, xAxisMax: 2, yAxisMin: 3, yAxisMax: 4 });
-        pinchObject.events.pointArea = { rect: { width: 1, height: 2 } };
+        pinchObject.events.componentSize = { width: 1, height: 2 };
         e = { preventDefault: sandbox.stub() };
         pinchObject.events.zoomstart(e);
         expect(pinchObject.events.started).to.equal('zoom');

--- a/src/picasso-definition/interactions/native.js
+++ b/src/picasso-definition/interactions/native.js
@@ -25,7 +25,7 @@ export default function native({ chart, actions, viewHandler }) {
             clearMinor({ chart, actions });
             const rectSize = target.rect?.computedPhysical;
             if (rectSize?.height && rectSize?.width) {
-              componentSize = rectSize;
+              componentSize = { ...rectSize };
             }
             zoom({ e, chart, componentSize, viewHandler });
             e.preventDefault();

--- a/src/picasso-definition/interactions/native.js
+++ b/src/picasso-definition/interactions/native.js
@@ -9,6 +9,7 @@ export default function native({ chart, actions, viewHandler }) {
     const dir = delta >= 0 ? 'next' : 'prev';
     comp.emit(dir);
   }
+  let componentSize;
   return {
     type: 'native',
     events: {
@@ -22,7 +23,11 @@ export default function native({ chart, actions, viewHandler }) {
             .filter((c) => c.key === KEYS.COMPONENT.POINT || c.key === KEYS.COMPONENT.HEAT_MAP);
           if (target) {
             clearMinor({ chart, actions });
-            zoom({ e, chart, pointComponent: target, viewHandler });
+            const rectSize = target.rect?.computedPhysical;
+            if (rectSize?.height && rectSize?.width) {
+              componentSize = rectSize;
+            }
+            zoom({ e, chart, componentSize, viewHandler });
             e.preventDefault();
           }
         }

--- a/src/picasso-definition/interactions/pan.js
+++ b/src/picasso-definition/interactions/pan.js
@@ -60,11 +60,9 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
       const rectSize = this.area[0]?.rect?.computedPhysical;
 
       if (rectSize?.height && rectSize?.width) {
-        this.componentSize = { ...rectSize };
         lastRectSize = { ...rectSize };
-      } else {
-        this.componentSize = { ...lastRectSize };
       }
+      this.componentSize = lastRectSize;
 
       return true;
     },

--- a/src/picasso-definition/interactions/pan.js
+++ b/src/picasso-definition/interactions/pan.js
@@ -53,7 +53,7 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
         .componentsFromPoint({ x: e.center.x, y: e.center.y })
         .filter((c) => c.key === KEYS.COMPONENT.POINT || c.key === KEYS.COMPONENT.HEAT_MAP);
 
-      if (!this.area) {
+      if (!this.area.length) {
         return false;
       }
 

--- a/src/picasso-definition/interactions/pan.js
+++ b/src/picasso-definition/interactions/pan.js
@@ -6,6 +6,7 @@ import clearMinor from '../../utils/clear-minor';
 
 const threshold = 10;
 const eventName = 'areaPan';
+let lastRectSize;
 
 const updateDataView = ({ event, props, viewHandler, rtl }) => {
   const { componentSize, xAxisMin, xAxisMax, yAxisMax, yAxisMin, miniChart } = props;
@@ -48,11 +49,24 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
         return false;
       }
 
-      [this.pointAreaPanned] = chart
+      this.area = chart
         .componentsFromPoint({ x: e.center.x, y: e.center.y })
         .filter((c) => c.key === KEYS.COMPONENT.POINT || c.key === KEYS.COMPONENT.HEAT_MAP);
 
-      return this.pointAreaPanned;
+      if (!this.area) {
+        return false;
+      }
+
+      const rectSize = this.area[0]?.rect?.computedPhysical;
+
+      if (rectSize?.height && rectSize?.width) {
+        this.componentSize = rectSize;
+        lastRectSize = rectSize;
+      } else {
+        this.componentSize = lastRectSize;
+      }
+
+      return true;
     },
   },
   events: {
@@ -73,16 +87,18 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
       const navWindowScale = scale * NUMBERS.MINI_CHART.RATIO;
       const initialDataView = viewHandler.getDataView();
       this[eventName] = {
-        componentSize: this.pointAreaPanned.rect,
+        componentSize: this.componentSize,
         ...initialDataView,
         miniChart: { panInMiniChart, navWindowScale },
       };
     },
     areaPanmove(e) {
+      if (!this.started) return;
       e.preventDefault();
       updateDataView({ event: e, props: this[eventName], viewHandler, rtl });
     },
     areaPanend(e) {
+      if (!this.started) return;
       e.preventDefault();
       viewHandler.setInteractionInProgress(false);
       updateDataView({ event: e, props: this[eventName], viewHandler, rtl });

--- a/src/picasso-definition/interactions/pan.js
+++ b/src/picasso-definition/interactions/pan.js
@@ -60,10 +60,10 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
       const rectSize = this.area[0]?.rect?.computedPhysical;
 
       if (rectSize?.height && rectSize?.width) {
-        this.componentSize = rectSize;
-        lastRectSize = rectSize;
+        this.componentSize = { ...rectSize };
+        lastRectSize = { ...rectSize };
       } else {
-        this.componentSize = lastRectSize;
+        this.componentSize = { ...lastRectSize };
       }
 
       return true;

--- a/src/picasso-definition/interactions/pinch.js
+++ b/src/picasso-definition/interactions/pinch.js
@@ -30,7 +30,7 @@ const pinch = ({ chart, actions, viewHandler, rtl }) => ({
         .componentsFromPoint({ x: e.center.x, y: e.center.y })
         .filter((c) => c.key === KEYS.COMPONENT.POINT || c.key === KEYS.COMPONENT.HEAT_MAP);
 
-      if (!this.area) {
+      if (!this.area.length) {
         return false;
       }
 

--- a/src/picasso-definition/interactions/pinch.js
+++ b/src/picasso-definition/interactions/pinch.js
@@ -37,11 +37,9 @@ const pinch = ({ chart, actions, viewHandler, rtl }) => ({
       const rectSize = this.area[0]?.rect?.computedPhysical;
 
       if (rectSize?.height && rectSize?.width) {
-        this.componentSize = { ...rectSize };
         lastRectSize = { ...rectSize };
-      } else {
-        this.componentSize = { ...lastRectSize };
       }
+      this.componentSize = lastRectSize;
 
       return true;
     },

--- a/src/picasso-definition/interactions/pinch.js
+++ b/src/picasso-definition/interactions/pinch.js
@@ -37,10 +37,10 @@ const pinch = ({ chart, actions, viewHandler, rtl }) => ({
       const rectSize = this.area[0]?.rect?.computedPhysical;
 
       if (rectSize?.height && rectSize?.width) {
-        this.componentSize = rectSize;
-        lastRectSize = rectSize;
+        this.componentSize = { ...rectSize };
+        lastRectSize = { ...rectSize };
       } else {
-        this.componentSize = lastRectSize;
+        this.componentSize = { ...lastRectSize };
       }
 
       return true;

--- a/src/utils/__tests__/event-utils.spec.js
+++ b/src/utils/__tests__/event-utils.spec.js
@@ -22,14 +22,14 @@ describe('eventToChartPoint', () => {
 
 describe('eventToComponentPoint', () => {
   let sandbox;
-  let component;
+  let componentSize;
   let chart;
   let event;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     event = { clientX: 1, clientY: 2 };
-    component = { rect: { computedPhysical: { x: 3, y: 4 } } };
+    componentSize = { x: 3, y: 4 };
     chart = { element: { getBoundingClientRect: sandbox.stub().returns({ left: 5, top: 6 }) } };
   });
 
@@ -38,6 +38,6 @@ describe('eventToComponentPoint', () => {
   });
 
   it('should return correct coordinate relative to component', () => {
-    expect(eventUtils.eventToComponentPoint(event, chart, component)).to.deep.equal({ x: -7, y: -8 });
+    expect(eventUtils.eventToComponentPoint(event, chart, componentSize)).to.deep.equal({ x: -7, y: -8 });
   });
 });

--- a/src/utils/event-utils.js
+++ b/src/utils/event-utils.js
@@ -12,8 +12,8 @@ export function eventToChartPoint(event, chart) {
   };
 }
 
-export function eventToComponentPoint(event, chart, component) {
+export function eventToComponentPoint(event, chart, componentSize) {
   const p = eventToChartPoint(event, chart);
-  const { x, y } = component.rect.computedPhysical;
+  const { x, y } = componentSize;
   return { x: p.x - x, y: p.y - y };
 }

--- a/src/view-handler/__tests__/zoom.spec.js
+++ b/src/view-handler/__tests__/zoom.spec.js
@@ -7,7 +7,7 @@ describe('zoom', () => {
   let create;
   let e;
   let chart;
-  let pointComponent;
+  let componentSize;
   let viewHandler;
   let dataView;
   let pinchZoomFactor;
@@ -18,8 +18,8 @@ describe('zoom', () => {
     viewHandler = { getMeta: sandbox.stub(), getDataView: sandbox.stub(), setMeta: sandbox.stub() };
     viewHandler.getMeta.returns({ scale: 1, maxScale: 2 ** 4.1, minScale: 2 ** -9.1 });
     sandbox.stub(eventUtils, 'eventToComponentPoint');
-    pointComponent = { rect: { computedPhysical: { width: 100, height: 100 } } };
-    create = () => zoom({ e, chart, pointComponent, viewHandler, pinchZoomFactor, buttonZoomDirection });
+    componentSize = { width: 100, height: 100 };
+    create = () => zoom({ e, chart, componentSize, viewHandler, pinchZoomFactor, buttonZoomDirection });
   });
 
   afterEach(() => {

--- a/src/view-handler/zoom.js
+++ b/src/view-handler/zoom.js
@@ -10,7 +10,7 @@ function transform(scale, start, end, factor) {
   return [newStart, newEnd];
 }
 
-export default function zoom({ e, chart, pointComponent, viewHandler, pinchZoomFactor, buttonZoomDirection }) {
+export default function zoom({ e, chart, componentSize, viewHandler, pinchZoomFactor, buttonZoomDirection }) {
   const { scale, maxScale, minScale } = viewHandler.getMeta();
   const { xAxisMin, xAxisMax, yAxisMin, yAxisMax } = viewHandler.getDataView();
   let zoomFactor;
@@ -20,8 +20,8 @@ export default function zoom({ e, chart, pointComponent, viewHandler, pinchZoomF
     fixedPoint = { normX: 0.5, normY: 0.5 };
   } else {
     zoomFactor = pinchZoomFactor || (e.deltaY > 0 ? ZOOM_SCALE : 1 / ZOOM_SCALE);
-    const p = eventToComponentPoint(e, chart, pointComponent);
-    const { width, height } = pointComponent.rect.computedPhysical;
+    const p = eventToComponentPoint(e, chart, componentSize);
+    const { width, height } = componentSize;
     fixedPoint = { normX: p.x / width, normY: p.y / height };
   }
   const newScale = zoomFactor * scale;


### PR DESCRIPTION
fix https://github.com/qlik-oss/sn-scatter-plot/issues/152 and https://github.com/qlik-oss/sn-scatter-plot/issues/153

1. Fix when sometimes areaPanend is called and this[eventName] is undefined even when pan start is not called. 
2. Fix when transition between bin and normal, component width and height is 0, causing calculated xAxisMin etc is NaN. The fix is to store width and height and use them if the component width and height is 0. 