### PR TITLE
fix: bin range selection highlight layer order

### DIFF
--- a/src/picasso-definition/components/__tests__/index.spec.js
+++ b/src/picasso-definition/components/__tests__/index.spec.js
@@ -78,13 +78,13 @@ describe('createComponents', () => {
       'legend-component-2',
       'heat-map-legend',
       'disclaimer',
+      'heat-map-highlight',
       'navigation-panel',
       'mini-chart-point',
       'mini-chart-background',
       'mini-chart-nav',
       'tooltip-1',
       'tooltip-2',
-      'heat-map-highlight',
       'heat-map-labels',
     ]);
   });

--- a/src/picasso-definition/components/index.js
+++ b/src/picasso-definition/components/index.js
@@ -35,10 +35,10 @@ export default function createComponents({ context, models, picasso, chart, acti
     ...colorService.custom.legendComponents(),
     createHeatMapLegend({ models, context, chart }),
     disclaimer,
+    createHeatMapHighLight({ chartModel, layoutService, actions }),
     createNavigationPanel({ layoutService, chartModel, chart, actions, context }),
     ...createMiniChart({ models }),
     ...tooltipService.getComponents(),
-    createHeatMapHighLight({ chartModel, layoutService, actions }),
     createHeatMapLabels({ themeService, chartModel, picasso, context }),
   ].filter(Boolean);
   // setDisplayOrder(components);


### PR DESCRIPTION
Fix bin data range selection highlight layer under min chart and navigation panel.
 
Before fix:
![Screenshot 2022-01-26 at 13 11 19](https://user-images.githubusercontent.com/25456307/151161500-231b2001-06bc-4313-8a2b-8329267e08a7.png)

After fix:
![Screenshot 2022-01-26 at 13 12 20](https://user-images.githubusercontent.com/25456307/151161514-9040bfea-ef58-489d-99b7-e2ff78f37ae1.png)

