### PR TITLE
fix: bin range highlight issue

### DIFF
--- a/src/interactive/lasso/event.js
+++ b/src/interactive/lasso/event.js
@@ -25,6 +25,7 @@ const lasso = ({ key, componentTargetKeys, requireFailure, recognizeWith }, opts
       e.preventDefault();
       if (this.started !== eventName) {
         opts.actions.select.emit('start', eventName);
+        opts.actions.select.emit('selectionStart');
         opts.actions.select.emit('binsRangeSelectionClear');
         this.chart.component(key).emit('lassoStart', e);
         this.started = eventName;

--- a/src/interactive/range/event.js
+++ b/src/interactive/range/event.js
@@ -48,7 +48,7 @@ const range = ({ eventName, key, fillTargets = [], requireFailure, recognizeWith
       e.preventDefault();
       opts.actions.select.emit('start', eventName);
       if (['binXRange', 'binYRange'].indexOf(eventName) > -1) {
-        opts.actions.select.emit('binRangeStart', eventName);
+        opts.actions.select.emit('selectionStart');
       }
       this.chart.component(key).emit('rangeStart', e);
       this.started = eventName;

--- a/src/interactive/tap/event.js
+++ b/src/interactive/tap/event.js
@@ -68,6 +68,7 @@ const tap = ({ targets, requireFailure, recognizeWith, components, eventName = '
             this.chart.brushSelectionIncludeMax = false;
             opts.actions.select.brushSelectionIncludeMax = false; // eslint-disable-line no-param-reassign
             opts.actions.select.emit('start', eventName, compsAtPoint);
+            opts.actions.select.emit('selectionStart');
           }
 
           if (shapes.length && components) {

--- a/src/picasso-components/heat-map-highlight/index.js
+++ b/src/picasso-components/heat-map-highlight/index.js
@@ -38,7 +38,7 @@ export default {
       ctx.putImageData(imageData, 0, 0, x * pixelRatio, y * pixelRatio, w * pixelRatio, h * pixelRatio);
     };
 
-    const onBinRangeStart = () => {
+    const onSelectionStart = () => {
       if (!imageData) {
         imageData = heatMapCanvasContext.getImageData(0, 0, heatMapCanvas.width, heatMapCanvas.height);
         const pixels = imageData.data;
@@ -69,12 +69,12 @@ export default {
       dirtyImageData.h = height;
     };
 
-    actions.select.removeAllListeners('binRangeStart');
+    actions.select.removeAllListeners('selectionStart');
     actions.select.removeAllListeners('binXRange');
     actions.select.removeAllListeners('binYRange');
     actions.select.removeAllListeners('binRangeHighlightClear');
     actions.select.removeAllListeners('binsRangeSelectionClear');
-    actions.select.on('binRangeStart', onBinRangeStart);
+    actions.select.on('selectionStart', onSelectionStart);
     actions.select.on('binXRange', onBinXRange);
     actions.select.on('binYRange', onBinYRange);
     actions.select.on('binRangeHighlightClear', onBinRangeHighlightClear);

--- a/src/picasso-definition/interactions/__tests__/native.spec.js
+++ b/src/picasso-definition/interactions/__tests__/native.spec.js
@@ -88,7 +88,9 @@ describe('native', () => {
         it('should not zoom if is in bin value selection', () => {
           chart.componentsFromPoint.withArgs({ x: 50, y: 100 }).returns([{ key: 'point-component' }]);
           isInBinValueSelection.default.returns(true);
-          expect(create().events.wheel(e)).to.equal(undefined);
+          create().events.wheel(e);
+          expect(zoom.default).not.to.have.been.called;
+          expect(clearMinor.default).not.to.have.been.called;
         });
 
         it('should get components', () => {

--- a/src/picasso-definition/interactions/__tests__/native.spec.js
+++ b/src/picasso-definition/interactions/__tests__/native.spec.js
@@ -2,6 +2,7 @@ import * as KEYS from '../../../constants/keys';
 import * as zoom from '../../../view-handler/zoom';
 import native from '../native';
 import * as clearMinor from '../../../utils/clear-minor';
+import * as isInBinValueSelection from '../../../utils/is-in-bin-value-selection';
 
 describe('native', () => {
   let sandbox;
@@ -49,6 +50,7 @@ describe('native', () => {
     };
     sandbox.stub(zoom, 'default');
     sandbox.stub(clearMinor, 'default');
+    sandbox.stub(isInBinValueSelection, 'default').returns(false);
     create = () =>
       native({
         chart,
@@ -83,6 +85,12 @@ describe('native', () => {
       });
 
       describe('wheel', () => {
+        it('should not zoom if is in bin value selection', () => {
+          chart.componentsFromPoint.withArgs({ x: 50, y: 100 }).returns([{ key: 'point-component' }]);
+          isInBinValueSelection.default.returns(true);
+          expect(create().events.wheel(e)).to.equal(undefined);
+        });
+
         it('should get components', () => {
           create().events.wheel(e);
           expect(chart.componentsFromPoint.withArgs({ x: 50, y: 100 })).to.have.been.called;

--- a/src/picasso-definition/interactions/__tests__/pan.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pan.spec.js
@@ -5,6 +5,7 @@ import pan from '../pan';
 import * as updateTapDataView from '../tap-mini-chart/update-tap-data-view';
 import * as getTapPosition from '../tap-mini-chart/tap-position';
 import * as clearMinor from '../../../utils/clear-minor';
+import * as isInBinValueSelection from '../../../utils/is-in-bin-value-selection';
 
 describe('pan', () => {
   let sandbox;
@@ -32,6 +33,7 @@ describe('pan', () => {
     sandbox.stub(getTapPosition, 'default').returns({ x: 1, y: 1 });
     sandbox.stub(updateTapDataView, 'default');
     sandbox.stub(clearMinor, 'default');
+    sandbox.stub(isInBinValueSelection, 'default').returns(false);
     panObject = pan({ chart, actions, viewHandler, rtl });
   });
 
@@ -60,6 +62,11 @@ describe('pan', () => {
 
       it('should return false if actions zoom is not enabled', () => {
         actions.zoom.enabled.returns(false);
+        expect(panObject.options.enable('', 'e')).to.equal(false);
+      });
+
+      it('should return false if is in bin vaule selection', () => {
+        isInBinValueSelection.default.returns(true);
         expect(panObject.options.enable('', 'e')).to.equal(false);
       });
 

--- a/src/picasso-definition/interactions/__tests__/pinch.spec.js
+++ b/src/picasso-definition/interactions/__tests__/pinch.spec.js
@@ -3,6 +3,7 @@ import KEYS from '../../../constants/keys';
 import * as zoom from '../../../view-handler/zoom';
 import pinch from '../pinch';
 import * as clearMinor from '../../../utils/clear-minor';
+import * as isInBinValueSelection from '../../../utils/is-in-bin-value-selection';
 
 describe('pinch', () => {
   let sandbox;
@@ -23,6 +24,7 @@ describe('pinch', () => {
     sandbox.stub(KEYS, 'COMPONENT').value({ POINT: 'point-component' });
     sandbox.stub(zoom, 'default');
     sandbox.stub(clearMinor, 'default');
+    sandbox.stub(isInBinValueSelection, 'default').returns(false);
     pinchObject = pinch({ chart, actions, viewHandler, rtl });
   });
 
@@ -46,6 +48,11 @@ describe('pinch', () => {
 
       it('should return false if actions zoom is not enabled', () => {
         actions.zoom.enabled.returns(false);
+        expect(pinchObject.options.enable('', 'e')).to.equal(false);
+      });
+
+      it('should return false if is in bin vaule selection', () => {
+        isInBinValueSelection.default.returns(true);
         expect(pinchObject.options.enable('', 'e')).to.equal(false);
       });
 

--- a/src/picasso-definition/interactions/native.js
+++ b/src/picasso-definition/interactions/native.js
@@ -1,6 +1,7 @@
 import KEYS from '../../constants/keys';
 import zoom from '../../view-handler/zoom';
 import clearMinor from '../../utils/clear-minor';
+import isInBinValueSelection from '../../utils/is-in-bin-value-selection';
 
 export default function native({ chart, actions, viewHandler }) {
   function scrollLegend(e, comp) {
@@ -16,6 +17,10 @@ export default function native({ chart, actions, viewHandler }) {
       wheel(e) {
         const point = { x: e.clientX, y: e.clientY };
         let target;
+
+        if (isInBinValueSelection(chart)) {
+          return;
+        }
 
         if (actions.zoom.enabled()) {
           [target] = chart

--- a/src/picasso-definition/interactions/pan.js
+++ b/src/picasso-definition/interactions/pan.js
@@ -3,6 +3,7 @@ import NUMBERS from '../../constants/numbers';
 import getTapPosition from './tap-mini-chart/tap-position';
 import updateTapDataView from './tap-mini-chart/update-tap-data-view';
 import clearMinor from '../../utils/clear-minor';
+import isInBinValueSelection from '../../utils/is-in-bin-value-selection';
 
 const threshold = 10;
 const eventName = 'areaPan';
@@ -46,6 +47,10 @@ const pan = ({ chart, actions, viewHandler, rtl }) => ({
       }
 
       if (!actions.zoom.enabled()) {
+        return false;
+      }
+
+      if (isInBinValueSelection(chart)) {
         return false;
       }
 

--- a/src/picasso-definition/interactions/pinch.js
+++ b/src/picasso-definition/interactions/pinch.js
@@ -1,6 +1,7 @@
 import KEYS from '../../constants/keys';
 import zoom from '../../view-handler/zoom';
 import clearMinor from '../../utils/clear-minor';
+import isInBinValueSelection from '../../utils/is-in-bin-value-selection';
 
 const EVENT_NAME = 'zoom';
 
@@ -23,6 +24,9 @@ const pinch = ({ chart, actions, viewHandler, rtl }) => ({
         return true;
       }
       if (!actions.zoom.enabled()) {
+        return false;
+      }
+      if (isInBinValueSelection(chart)) {
         return false;
       }
 

--- a/src/utils/__tests__/is-in-bin-range-selection.spec.js
+++ b/src/utils/__tests__/is-in-bin-range-selection.spec.js
@@ -1,0 +1,40 @@
+import isInBinRangeSelection from '../is-in-bin-range-selection';
+
+describe('isInBinRangeSelection', () => {
+  let sandbox;
+  let chart;
+  let brushFn;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    brushFn = {
+      brushes: sandbox.stub().returns([{ id: 'binData/binX' }]),
+    };
+    chart = {
+      brush: () => brushFn,
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return true if is binx range selection', () => {
+    expect(isInBinRangeSelection(chart)).to.equal(true);
+  });
+
+  it('should return true if is binY range selection', () => {
+    brushFn.brushes = sandbox.stub().returns([{ id: 'binData/binY' }]);
+    expect(isInBinRangeSelection(chart)).to.equal(true);
+  });
+
+  it('should return false if brushArray is empty array', () => {
+    brushFn.brushes = sandbox.stub().returns([]);
+    expect(isInBinRangeSelection(chart)).to.equal(false);
+  });
+
+  it('should return false if is not binx or binY range selection', () => {
+    brushFn.brushes = sandbox.stub().returns([{ id: 'binData/bin' }]);
+    expect(isInBinRangeSelection(chart)).to.equal(false);
+  });
+});

--- a/src/utils/__tests__/is-in-bin-value-selection.spec.js
+++ b/src/utils/__tests__/is-in-bin-value-selection.spec.js
@@ -1,0 +1,40 @@
+import isInBinValueSelection from '../is-in-bin-value-selection';
+
+describe('isInBinValueSelection', () => {
+  let sandbox;
+  let chart;
+  let brushFn;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    brushFn = {
+      brushes: sandbox.stub().returns([{ type: 'value', id: 'binData/bin' }]),
+    };
+    chart = {
+      brush: () => brushFn,
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return true if is bin value selection', () => {
+    expect(isInBinValueSelection(chart)).to.equal(true);
+  });
+
+  it('should return false if brushArray is empty array', () => {
+    brushFn.brushes = sandbox.stub().returns([]);
+    expect(isInBinValueSelection(chart)).to.equal(false);
+  });
+
+  it('should return false if is not bin value selection', () => {
+    brushFn.brushes = sandbox.stub().returns([{ type: 'range', id: 'binData/bin' }]);
+    expect(isInBinValueSelection(chart)).to.equal(false);
+  });
+
+  it('should return false if is bin value selection with wrong id', () => {
+    brushFn.brushes = sandbox.stub().returns([{ type: 'value', id: 'binData/binX' }]);
+    expect(isInBinValueSelection(chart)).to.equal(false);
+  });
+});

--- a/src/utils/is-in-bin-value-selection.js
+++ b/src/utils/is-in-bin-value-selection.js
@@ -1,0 +1,8 @@
+export default function isInBinValueSelection(chart) {
+  const brush = chart.brush('selection');
+  const brushArray = brush.brushes();
+  if (brushArray?.length && brushArray[0]?.type === 'value' && brushArray[0]?.id === 'binData/bin') {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Fix when first doing selections with tap or lasso, and then doing bin range selection, the range selection base image is not correct.

The fix is when start doing selection and the image is undefined, we store the image.
Disable pan zoom and pinch when is in bin value selection as the old scatter plot. So can avoid doing value selection and move the chat, then do range selection, the base image is not correct.

See the issue here:

https://user-images.githubusercontent.com/25456307/151179099-f636ca32-ecbf-45f0-8f4e-cb53e945ffc9.mov


After fix:

https://user-images.githubusercontent.com/25456307/151323351-64743759-91d8-4061-853d-d1892a8e81b3.mov


