### PR TITLE
fix: update scale when update dataview

### DIFF
--- a/src/picasso-definition/components/navigation-panel/__tests__/index.spec.js
+++ b/src/picasso-definition/components/navigation-panel/__tests__/index.spec.js
@@ -45,7 +45,7 @@ describe('createNavigationPanel', () => {
     sandbox.restore();
   });
 
-  it('should return false if is snapshot', () => {
+  it('should return empty array if is snapshot', () => {
     layoutService.meta.isSnapshot = true;
     expect(create()).to.deep.equal([]);
   });

--- a/src/view-handler/__tests__/index.spec.js
+++ b/src/view-handler/__tests__/index.spec.js
@@ -49,7 +49,7 @@ describe('createViewHandler', () => {
 
   it('should return a view handler with proper setDataView method, case 1: not home state', () => {
     viewHandler.setMeta({
-      homeStateDataView: { xAxisMin: -100, xAxisMax: 200, yAxisMin: 0, yAxisMax: 100 },
+      homeStateDataView: { xAxisMin: -200, xAxisMax: 200, yAxisMin: 0, yAxisMax: 100 },
       scale: 2,
     });
     viewHandler.setDataView(myDataView);
@@ -57,6 +57,7 @@ describe('createViewHandler', () => {
       .been.calledOnce;
     expect(extremumModel.command.updateExtrema).to.have.been.calledOnce;
     expect(viewHandler.getMeta().isHomeState).to.equal(false);
+    expect(viewHandler.getMeta().scale).to.equal(0.25);
   });
 
   it('should return a view handler with proper setDataView method, case 2: home state', () => {
@@ -69,6 +70,7 @@ describe('createViewHandler', () => {
       .been.calledOnce;
     expect(extremumModel.command.updateExtrema).to.have.been.calledOnce;
     expect(viewHandler.getMeta().isHomeState).to.equal(true);
+    expect(viewHandler.getMeta().scale).to.equal(1);
   });
 
   it('should return a view handler with proper getMeta method', () => {

--- a/src/view-handler/index.js
+++ b/src/view-handler/index.js
@@ -29,6 +29,7 @@ export default function createViewHandler({ viewState, extremumModel, layoutServ
         meta.isHomeState = false;
       }
       extremumModel.command.updateExtrema(dataView, meta.isHomeState);
+      meta.scale = (xMax1 - xMin1) / (xMax2 - xMin2);
       viewState.set('dataView', dataView);
     },
 

--- a/src/view-handler/zoom.js
+++ b/src/view-handler/zoom.js
@@ -36,5 +36,4 @@ export default function zoom({ e, chart, componentSize, viewHandler, pinchZoomFa
     yAxisMin: yMin,
     yAxisMax: yMax,
   });
-  viewHandler.setMeta({ scale: newScale });
 }


### PR DESCRIPTION
To fix: https://github.com/qlik-oss/sn-scatter-plot/issues/220
The issue happens because scale is not updated after pressing home button (thanks to @jjxie for pointing out the root cause). This can be fixed by updating the scale everytime you setDataView.