### PR TITLE
fix: set min bin width/height to 1 px

### DIFF
--- a/src/picasso-definition/components/heat-map/index.js
+++ b/src/picasso-definition/components/heat-map/index.js
@@ -54,8 +54,8 @@ export default function createHeatMap(chartModel) {
         const binWidth = Math.abs(firstBin.qText[0] - firstBin.qText[2]);
         const binHeight = Math.abs(firstBin.qText[1] - firstBin.qText[3]);
 
-        binWidthPx = (binWidth * size.width) / (dataView.xAxisMax - dataView.xAxisMin);
-        binHeightPx = (binHeight * size.height) / (dataView.yAxisMax - dataView.yAxisMin);
+        binWidthPx = Math.max(1, (binWidth * size.width) / (dataView.xAxisMax - dataView.xAxisMin));
+        binHeightPx = Math.max(1, (binHeight * size.height) / (dataView.yAxisMax - dataView.yAxisMin));
       }
     },
     rendererSettings: {


### PR DESCRIPTION
There is a scenario where all data points in a bin has the same x and/or y values. This can cause bin width/height less than 1 px and the bins are almost invisible.