### PR TITLE
fix: change svg to canvas for renderer of reference line labels

### DIFF
--- a/src/picasso-definition/components/reference-lines/__tests__/labels.spec.js
+++ b/src/picasso-definition/components/reference-lines/__tests__/labels.spec.js
@@ -109,7 +109,6 @@ describe('createRefLineLabels', () => {
     expect(result).to.deep.equal({
       key: 'reference-line-labels-X',
       type: 'reference-line-labels',
-      renderer: 'svg',
       labels: [
         {
           text: 'X ref label',
@@ -175,7 +174,6 @@ describe('createRefLineLabels', () => {
     expect(result).to.deep.equal({
       key: 'reference-line-labels-X',
       type: 'reference-line-labels',
-      renderer: 'svg',
       labels: [
         {
           text: 'X ref label',
@@ -237,7 +235,6 @@ describe('createRefLineLabels', () => {
     expect(result).to.deep.equal({
       key: 'reference-line-labels-Y',
       type: 'reference-line-labels',
-      renderer: 'svg',
       labels: [
         {
           text: 'Y ref label',
@@ -307,7 +304,6 @@ describe('createRefLineLabels', () => {
     expect(result).to.deep.equal({
       key: 'reference-line-labels-Y',
       type: 'reference-line-labels',
-      renderer: 'svg',
       labels: [
         {
           text: 'Y ref label',

--- a/src/picasso-definition/components/reference-lines/labels.js
+++ b/src/picasso-definition/components/reference-lines/labels.js
@@ -64,7 +64,6 @@ export default function createRefLineLabels({ models, context, scale, key, dock,
   const refLineLabelsDef = {
     key,
     type: 'reference-line-labels',
-    renderer: 'svg',
     labels,
     scale,
     localeInfo,


### PR DESCRIPTION
For performance reason (avoiding possible crash on mobile phone due to svg nodes overloading browsers).