### PR TITLE
fix: clear bin highlight img when clear selection

### DIFF
--- a/src/services/selection-service/__tests__/index.spec.js
+++ b/src/services/selection-service/__tests__/index.spec.js
@@ -136,7 +136,7 @@ describe('selection-service', () => {
 
           it('should call clearMinor four times and emit event when is bin data', () => {
             cleared = true;
-            selectionInfo = { event: 'xRange', components: ['heat-map-highlight'] };
+            selectionInfo = { event: 'binXRange', components: ['heat-map-highlight'] };
             getConfig().selectionActions.clear({ clearMinor, clearLegend, selectionInfo, cleared });
             expect(clearMinor.callCount).to.equal(4);
             expect(clearMinor).to.have.been.calledWith({ eventName: 'xRange', componentName: 'x-range-brush' });
@@ -172,7 +172,7 @@ describe('selection-service', () => {
             expect(actions.select.emit).to.not.have.been.called;
           });
 
-          it('should call clearMinor four times and emit event when is bin data', () => {
+          it('should call clearMinor four times and not emit event when is bin data', () => {
             cleared = true;
             selectionInfo = { event: 'range', components: ['heat-map-highlight'] };
             getConfig().selectionActions.clear({ clearMinor, clearLegend, selectionInfo, cleared });
@@ -187,7 +187,7 @@ describe('selection-service', () => {
               eventName: 'binYRange',
               componentName: 'bin-y-range-brush',
             });
-            expect(actions.select.emit).to.have.been.calledWith('binsRangeSelectionClear');
+            expect(actions.select.emit).to.not.have.been.called;
           });
         });
 

--- a/src/services/selection-service/index.js
+++ b/src/services/selection-service/index.js
@@ -35,12 +35,13 @@ export default function createService({ chart, actions, selections }) {
       selectionActions: {
         clear: ({ clearMinor, clearLegend, selectionInfo, cleared }) => {
           const isSelectingRanges = ['xRange', 'yRange', 'binXRange', 'binYRange'].includes(selectionInfo.event);
+          const isSelectingBinRanges = ['binXRange', 'binYRange'].includes(selectionInfo.event);
           if (cleared || !isSelectingRanges) {
             clearMinor({ eventName: 'xRange', componentName: KEYS.BRUSH.X_RANGE });
             clearMinor({ eventName: 'yRange', componentName: KEYS.BRUSH.Y_RANGE });
             clearMinor({ eventName: 'binXRange', componentName: KEYS.BRUSH.BIN_X_RANGE });
             clearMinor({ eventName: 'binYRange', componentName: KEYS.BRUSH.BIN_Y_RANGE });
-            if (selectionInfo.components.includes(KEYS.COMPONENT.HEAT_MAP_HIGHLIGHT)) {
+            if (isSelectingBinRanges) {
               actions.select.emit('binsRangeSelectionClear');
             }
           }


### PR DESCRIPTION
Fix the issue when having bin range selection and then clear selection, the highlight img is still there.

Before fixing:

https://user-images.githubusercontent.com/25456307/152179629-cc18c4ce-280c-41da-9e44-5e0461b979a9.mov



After fixing:

https://user-images.githubusercontent.com/25456307/152179525-a64e10d3-5b76-461b-8eaa-c671c4003453.mov


