### PR TITLE
fix: set lower limit for transformation

### DIFF
--- a/src/constants/__tests__/numbers.spec.js
+++ b/src/constants/__tests__/numbers.spec.js
@@ -11,6 +11,7 @@ describe('numbers', () => {
       'MAX_NR_SCATTER',
       'MAX_NR_ANIMATION',
       'MINI_CHART',
+      'MIN_TRANSFORMATION',
       'NAVIGATION_PANEL',
       'WINDOW_SIZE_BASE',
     ]);

--- a/src/constants/numbers.js
+++ b/src/constants/numbers.js
@@ -38,6 +38,7 @@ export default {
   // Ratio = minichart_size/chart_size, Padding: away from the bottom right corner
   MINI_CHART: { RATIO: 0.15, PADDING: 10 },
   MAX_NR_ANIMATION: 1000,
+  MIN_TRANSFORMATION: 100,
 
   NAVIGATION_PANEL: { BUTTON_WIDTH: 45 },
   WINDOW_SIZE_BASE: 300,

--- a/src/picasso-definition/components/__tests__/index.spec.js
+++ b/src/picasso-definition/components/__tests__/index.spec.js
@@ -81,6 +81,7 @@ describe('createComponents', () => {
       'heat-map-legend',
       'disclaimer',
       'heat-map-highlight',
+      'heat-map-labels',
       'home',
       'up',
       'mini-chart-point',
@@ -88,7 +89,6 @@ describe('createComponents', () => {
       'mini-chart-nav',
       'tooltip-1',
       'tooltip-2',
-      'heat-map-labels',
     ]);
   });
 

--- a/src/picasso-definition/components/heat-map-labels/__test__/index.spec.js
+++ b/src/picasso-definition/components/heat-map-labels/__test__/index.spec.js
@@ -9,6 +9,7 @@ describe('heat-map-labels', () => {
   let create;
   let chartModel;
   let viewHandler;
+  let chart;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -30,9 +31,10 @@ describe('heat-map-labels', () => {
         HEAT_MAP_LABELS: 'heat-map-labels',
       },
     });
-    viewHandler = { transform: 'transform-function', animationEnabled: undefined };
+    viewHandler = { transform: sandbox.stub(), animationEnabled: undefined };
     chartModel = { query: { getViewHandler: sandbox.stub().returns(viewHandler) } };
-    create = () => createHeatMapLabels({ themeService, chartModel, picasso, context });
+    chart = { findShapes: sandbox.stub().returns([]) };
+    create = () => createHeatMapLabels({ themeService, chartModel, picasso, context, chart });
   });
 
   afterEach(() => {
@@ -185,7 +187,8 @@ describe('heat-map-labels', () => {
 
           describe('rendererSettings', () => {
             it('should have correct transform function', () => {
-              expect(create().rendererSettings.transform).to.equal('transform-function');
+              create().rendererSettings.transform();
+              expect(viewHandler.transform).to.have.been.calledOnce;
             });
             it('should have correct buffer size', () => {
               const rect = { computedPhysical: { width: 200, height: 150 } };

--- a/src/picasso-definition/components/heat-map-labels/index.js
+++ b/src/picasso-definition/components/heat-map-labels/index.js
@@ -1,7 +1,7 @@
 import KEYS from '../../../constants/keys';
 import MODES from '../../../constants/modes';
 
-export default function createHeatMapLabels({ themeService, chartModel, picasso, context }) {
+export default function createHeatMapLabels({ themeService, chartModel, picasso, context, chart }) {
   const formatter = picasso.formatter('q-number');
   const style = themeService.getStyles();
   const { fontFamily, numFontSize } = style.label?.value || {};
@@ -49,7 +49,8 @@ export default function createHeatMapLabels({ themeService, chartModel, picasso,
       trackBy: () => Math.random(),
     },
     rendererSettings: {
-      transform,
+      transform: () =>
+        transform(chart.findShapes('rect').filter((node) => node.key === KEYS.COMPONENT.HEAT_MAP).length),
       canvasBufferSize: (rect) => ({
         width: rect.computedPhysical.width + 100,
         height: rect.computedPhysical.height + 100,

--- a/src/picasso-definition/components/heat-map/__tests__/index.spec.js
+++ b/src/picasso-definition/components/heat-map/__tests__/index.spec.js
@@ -7,6 +7,7 @@ describe('heat-map', () => {
   let dataHandler;
   let create;
   let viewHandler;
+  let chart;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -30,7 +31,7 @@ describe('heat-map', () => {
     }));
     viewHandler = {
       getDataView: sandbox.stub().returns({ xAxisMin: 0, xAxisMax: 4000, yAxisMin: 0, yAxisMax: 10 }),
-      transform: 'transform-function',
+      transform: sandbox.stub(),
       animationEnabled: undefined,
     };
     dataHandler = {
@@ -44,8 +45,8 @@ describe('heat-map', () => {
         getDataHandler: () => dataHandler,
       },
     };
-
-    create = () => createHeatMap(chartModel);
+    chart = { findShapes: sandbox.stub().returns([]) };
+    create = () => createHeatMap({ chartModel, chart });
   });
 
   afterEach(() => {
@@ -163,7 +164,8 @@ describe('heat-map', () => {
 
     describe('rendererSettings', () => {
       it('should have correct transform function', () => {
-        expect(create().rendererSettings.transform).to.equal('transform-function');
+        create().rendererSettings.transform();
+        expect(viewHandler.transform).to.have.been.calledOnce;
       });
       it('should have correct buffer size', () => {
         const rect = { computedPhysical: { width: 200, height: 150 } };

--- a/src/picasso-definition/components/heat-map/index.js
+++ b/src/picasso-definition/components/heat-map/index.js
@@ -1,7 +1,7 @@
 import KEYS from '../../../constants/keys';
 import createBrush from '../../brush/heat-map-brush';
 
-export default function createHeatMap(chartModel) {
+export default function createHeatMap({ chartModel, chart }) {
   const viewHandler = chartModel.query.getViewHandler();
   const { transform } = viewHandler;
   const dataHandler = chartModel.query.getDataHandler();
@@ -78,7 +78,8 @@ export default function createHeatMap(chartModel) {
     },
 
     rendererSettings: {
-      transform,
+      transform: () =>
+        transform(chart.findShapes('rect').filter((node) => node.key === KEYS.COMPONENT.HEAT_MAP).length),
       canvasBufferSize: (rect) => ({
         width: rect.computedPhysical.width + 100,
         height: rect.computedPhysical.height + 100,

--- a/src/picasso-definition/components/index.js
+++ b/src/picasso-definition/components/index.js
@@ -26,8 +26,8 @@ export default function createComponents({ context, models, picasso, chart, acti
     ...createOutOfBoundsSpace({ models }),
     createGridLines(models),
     ...createReferenceLines({ models, context }),
-    createPoint(models),
-    createHeatMap(chartModel),
+    createPoint({ layoutService, colorService, chartModel, chart }),
+    createHeatMap({ chartModel, chart }),
     ...trendLinesService.getComponents(),
     ...createAxes({ models }),
     ...createAxisTitles({ models, context }),
@@ -37,10 +37,10 @@ export default function createComponents({ context, models, picasso, chart, acti
     createHeatMapLegend({ models, context, chart }),
     disclaimer,
     createHeatMapHighLight({ chartModel, layoutService, actions, context }),
+    createHeatMapLabels({ themeService, chartModel, picasso, context, chart }),
     ...createNavigationPanel({ layoutService, chartModel, chart, actions, context }),
-    ...createMiniChart({ models }),
+    ...createMiniChart({ models, context }),
     ...tooltipService.getComponents(),
-    createHeatMapLabels({ themeService, chartModel, picasso, context }),
   ].filter(Boolean);
   // setDisplayOrder(components);
 

--- a/src/picasso-definition/components/point-labels/__test__/index.spec.js
+++ b/src/picasso-definition/components/point-labels/__test__/index.spec.js
@@ -32,12 +32,14 @@ describe('point-labels', () => {
     viewHandler = {
       redererSettings: 'renderer-settings',
       animationEnabled: false,
-      transform: 'transform-function',
+      transform: sandbox.stub(),
     };
     chartModel = { query: { getViewHandler: sandbox.stub().returns(viewHandler) } };
     models = { layoutService, themeService, chartModel };
-    chart = { component: sandbox.stub().returns({ rect: { width: 500, height: 500 } }) };
-    create = () => createPointLabels({ models, chart });
+    chart = {
+      component: sandbox.stub().returns({ rect: { width: 500, height: 500 } }),
+      findShapes: sandbox.stub().returns([]),
+    };
     labels = { mode: 1 };
     layoutService.getLayoutValue.withArgs('labels').returns(labels);
     themeService.getStyles.returns({ label: { value: { fontFamily: 'Sans serif', fontSize: '1px', color: 'red' } } });
@@ -47,6 +49,7 @@ describe('point-labels', () => {
         POINT_LABELS: 'point-labels',
       },
     });
+    create = () => createPointLabels({ models, chart });
   });
 
   afterEach(() => {
@@ -104,7 +107,8 @@ describe('point-labels', () => {
 
     describe('rendererSettings', () => {
       it('should have correct transform function', () => {
-        expect(create().rendererSettings.transform).to.equal('transform-function');
+        create().rendererSettings.transform();
+        expect(viewHandler.transform).to.have.been.calledOnce;
       });
       it('should have correct buffer size', () => {
         const compRect = { computedPhysical: { width: 200, height: 150 } };

--- a/src/picasso-definition/components/point-labels/index.js
+++ b/src/picasso-definition/components/point-labels/index.js
@@ -76,7 +76,12 @@ export default function createPointLabels({ models, chart }) {
       },
     },
     rendererSettings: {
-      transform,
+      transform: () =>
+        transform(
+          [...chart.findShapes('circle'), ...chart.findShapes('path')].filter(
+            (node) => node.key === KEYS.COMPONENT.POINT
+          ).length
+        ),
       canvasBufferSize: (rect) => ({
         width: rect.computedPhysical.width + 100,
         height: rect.computedPhysical.height + 100,

--- a/src/picasso-definition/components/point/__tests__/index.spec.js
+++ b/src/picasso-definition/components/point/__tests__/index.spec.js
@@ -18,6 +18,7 @@ describe('point', () => {
   const wsm = 1;
   let rect;
   let viewHandler;
+  let chart;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -50,7 +51,7 @@ describe('point', () => {
       getMeta: sandbox.stub().returns({ isBinnedData: false }),
     };
     chartModel.query.getDataHandler.returns(dataHandler);
-    viewHandler = { redererSettings: 'renderer-settings', animationEnabled: false, transform: 'transform-function' };
+    viewHandler = { redererSettings: 'renderer-settings', animationEnabled: false, transform: sandbox.stub() };
     chartModel.query.getViewHandler.returns(viewHandler);
     canvasBufferSizeStub = sandbox.stub();
     rect = {
@@ -65,7 +66,6 @@ describe('point', () => {
     });
 
     colorService = { getColor: sandbox.stub() };
-
     d = {
       datum: {
         size: {
@@ -75,12 +75,13 @@ describe('point', () => {
     };
 
     sandbox.stub(movePath, 'default').returns('new-path');
-
+    chart = { findShapes: sandbox.stub().returns([]) };
     create = () =>
       createPoint({
         layoutService,
         colorService,
         chartModel,
+        chart,
       });
   });
 
@@ -175,7 +176,8 @@ describe('point', () => {
 
   describe('rendererSettings', () => {
     it('should have correct transform function', () => {
-      expect(create().rendererSettings.transform).to.equal('transform-function');
+      create().rendererSettings.transform();
+      expect(viewHandler.transform).to.have.been.calledOnce;
     });
     it('should have correct buffer size', () => {
       const compRect = { computedPhysical: { width: 200, height: 150 } };

--- a/src/picasso-definition/components/point/index.js
+++ b/src/picasso-definition/components/point/index.js
@@ -5,7 +5,7 @@ import createSizeScale from '../../scales/size';
 import createBrush from '../../brush/point-brush';
 import movePath from '../../../utils/move-path';
 
-export default function createPoint({ layoutService, colorService, chartModel }) {
+export default function createPoint({ layoutService, colorService, chartModel, chart }) {
   let windowSizeMultiplier;
   const sizeScaleFn = createSizeScale(layoutService);
   const viewHandler = chartModel.query.getViewHandler();
@@ -58,7 +58,12 @@ export default function createPoint({ layoutService, colorService, chartModel })
       },
     },
     rendererSettings: {
-      transform,
+      transform: () =>
+        transform(
+          [...chart.findShapes('circle'), ...chart.findShapes('path')].filter(
+            (node) => node.key === KEYS.COMPONENT.POINT
+          ).length
+        ),
       canvasBufferSize: (rect) => ({
         width: rect.computedPhysical.width + 100,
         height: rect.computedPhysical.height + 100,

--- a/src/view-handler/index.js
+++ b/src/view-handler/index.js
@@ -64,7 +64,11 @@ export default function createViewHandler({ viewState, extremumModel, layoutServ
       return layoutService.getHyperCubeValue('qSize.qcy', 0) <= NUMBERS.MAX_NR_ANIMATION && !interactionInProgress;
     },
 
-    transform: () => {
+    transform: (numberOfNodes) => {
+      if (numberOfNodes < NUMBERS.MIN_TRANSFORMATION) {
+        return false;
+      }
+
       if (interactionInProgress) {
         const { deltaX, deltaY } = viewHandler.getDataView();
         return {
@@ -76,6 +80,7 @@ export default function createViewHandler({ viewState, extremumModel, layoutServ
           verticalMoving: deltaY,
         };
       }
+
       return false;
     },
   };


### PR DESCRIPTION
## Description
It is unnecessary to do transformation when the number of points or bins is lower than a threshold. I set it at 100, based on the below tests.
## Rendering time tests
### Macbook pro 2019
Based on the below tests, at 118 bins (+118 labels) the rendering time is roughly the same. Only above 118 bins that we need transformation.
![rendering time](https://user-images.githubusercontent.com/70384379/152237574-7562d7f7-75b4-456d-ab1d-14a6fd523ad1.png)
### Iphone 12
For Iphone 12, 50 seems be be a better threshold. However, since the rendering times are much lower than on Macbook, it also makes sense to set the threshold at 100.
![iphone12](https://user-images.githubusercontent.com/70384379/152242831-400d9eaa-fd34-45f6-847c-ed9c3a56894e.png)

## Verification
Sanity check: console log when transformation happens.
### Bin data (118 bins)
- Threshold set at 118 (should transform)

https://user-images.githubusercontent.com/70384379/152244400-cdb01071-f8f1-4e94-bea3-9c606b22e5da.mov

- Threshold set at 119 (should not transform)

https://user-images.githubusercontent.com/70384379/152245188-1308427e-4754-4fd5-a06f-3a8e961572df.mov

### Point data (26 points)
- Threshold set at 25 (should transform)

https://user-images.githubusercontent.com/70384379/152245444-2f95c884-3047-45f6-9fb6-cf28dc659024.mov

- Threshold set at 27 (should not transform)


https://user-images.githubusercontent.com/70384379/152245586-54f8ba93-39ed-41b5-9d26-54b9423a3eec.mov



