### PR TITLE
fix: bin range highlight color issue

### DIFF
--- a/src/interactive/lasso/event.js
+++ b/src/interactive/lasso/event.js
@@ -24,9 +24,9 @@ const lasso = ({ key, componentTargetKeys, requireFailure, recognizeWith }, opts
     lassostart(e) {
       e.preventDefault();
       if (this.started !== eventName) {
-        opts.actions.select.emit('start', eventName);
-        opts.actions.select.emit('selectionStart');
         opts.actions.select.emit('binsRangeSelectionClear');
+        opts.actions.select.emit('selectionStart');
+        opts.actions.select.emit('start', eventName);
         this.chart.component(key).emit('lassoStart', e);
         this.started = eventName;
       }

--- a/src/interactive/range/event.js
+++ b/src/interactive/range/event.js
@@ -46,10 +46,10 @@ const range = ({ eventName, key, fillTargets = [], requireFailure, recognizeWith
         opts.actions.select.brushSelectionIncludeMax = true; // eslint-disable-line no-param-reassign
       }
       e.preventDefault();
-      opts.actions.select.emit('start', eventName);
       if (['binXRange', 'binYRange'].indexOf(eventName) > -1) {
         opts.actions.select.emit('selectionStart');
       }
+      opts.actions.select.emit('start', eventName);
       this.chart.component(key).emit('rangeStart', e);
       this.started = eventName;
     },

--- a/src/interactive/tap/event.js
+++ b/src/interactive/tap/event.js
@@ -67,8 +67,9 @@ const tap = ({ targets, requireFailure, recognizeWith, components, eventName = '
           if (shapes.length || !isLegend) {
             this.chart.brushSelectionIncludeMax = false;
             opts.actions.select.brushSelectionIncludeMax = false; // eslint-disable-line no-param-reassign
-            opts.actions.select.emit('start', eventName, compsAtPoint);
+            opts.actions.select.emit('binsRangeSelectionClear');
             opts.actions.select.emit('selectionStart');
+            opts.actions.select.emit('start', eventName, compsAtPoint);
           }
 
           if (shapes.length && components) {

--- a/src/picasso-components/heat-map-highlight/index.js
+++ b/src/picasso-components/heat-map-highlight/index.js
@@ -42,6 +42,10 @@ export default {
       if (!imageData) {
         heatMapCanvas.style.opacity = 1;
         imageData = heatMapCanvasContext.getImageData(0, 0, heatMapCanvas.width, heatMapCanvas.height);
+        const pixels = imageData.data;
+        for (let i = 3, n = heatMapCanvas.width * heatMapCanvas.height * 4; i < n; i += 4) {
+          pixels[i] = pixels[i] === 0 ? 0 : 255;
+        }
       }
     };
 

--- a/src/picasso-components/heat-map-highlight/index.js
+++ b/src/picasso-components/heat-map-highlight/index.js
@@ -40,11 +40,8 @@ export default {
 
     const onSelectionStart = () => {
       if (!imageData) {
+        heatMapCanvas.style.opacity = 1;
         imageData = heatMapCanvasContext.getImageData(0, 0, heatMapCanvas.width, heatMapCanvas.height);
-        const pixels = imageData.data;
-        for (let i = 3, n = heatMapCanvas.width * heatMapCanvas.height * 4; i < n; i += 4) {
-          pixels[i] = pixels[i] === 0 ? 0 : 255;
-        }
       }
     };
 


### PR DESCRIPTION
Fix the issue when doing bin range selection, sometimes the color is not correct. This is due to how canvas deals with color with opacity. 
`Due to the lossy nature of converting to and from premultiplied alpha color values, pixels that have just been set using putImageData() might be returned to an equivalent getImageData() as different values. `

The issue is like this, in some sizes unexpected colors (light blue) will show up.
![Screenshot 2022-02-04 at 09 27 42](https://user-images.githubusercontent.com/25456307/152497185-eec8d1ce-30be-4cca-999f-1db891b72c0e.png)

The fix now changes the canvas opacity to 1 before get image, so all the colors are solid color. 
But in one scenarios, tap on chart to get into selection mode, then pan/zoom the chart. Since the dataview changes, we will render the highlight component and also need to get a new image, this image is with inactive style (opacity: 0.3, not added to canvas directly). So we still get an image color with opacity 0.3. To fix this issue, we still need change color using 255 way which still get the issue above mentioned. 

I have tried to set brush inactive and active style to 1 and change canvas opacity to 0.3 when doing selections. I get more issues with from range change to lasso or tap selection, and double or reduced opacity issues. I think the fix now is the best I can do now, just not perfect in one scenarios.
 