### PR TITLE
fix: improve grid lines

### DIFF
--- a/src/models/tick-model/ticks/__tests__/index.spec.js
+++ b/src/models/tick-model/ticks/__tests__/index.spec.js
@@ -35,7 +35,8 @@ describe('getTicks', () => {
   it('should get niced major ticks when explicitType is none', () => {
     distance = 500;
     explicitType = 'none';
-    tickHelper.getTicksAndMinMax.withArgs(scale, true, 1, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.getTicksAndMinMax.withArgs(scale, true, 2, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.valid.returns(true);
     sandbox.stub(getMinorTicks, 'default').returns([500]);
     expect(create()).to.deep.equal({
       ticks: [
@@ -101,7 +102,8 @@ describe('getTicks', () => {
   it('should get correct min max when explicitType is min', () => {
     distance = 500;
     explicitType = 'min';
-    tickHelper.getTicksAndMinMax.withArgs(scale, true, 1, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.getTicksAndMinMax.withArgs(scale, true, 2, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.valid.returns(true);
     sandbox.stub(getMinorTicks, 'default').returns([500]);
     expect(create()).to.deep.equal({
       ticks: [
@@ -116,7 +118,8 @@ describe('getTicks', () => {
   it('should get correct min max when explicitType is max', () => {
     distance = 500;
     explicitType = 'max';
-    tickHelper.getTicksAndMinMax.withArgs(scale, true, 1, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.getTicksAndMinMax.withArgs(scale, true, 2, 1, 998).returns({ ticks: [0, 1000], min: 0, max: 1000 });
+    tickHelper.valid.returns(true);
     sandbox.stub(getMinorTicks, 'default').returns([500]);
     expect(create()).to.deep.equal({
       ticks: [

--- a/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
+++ b/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
@@ -79,22 +79,22 @@ describe('valid', () => {
     sandbox.restore();
   });
 
-  it('should return true if the space between ticks is larger than or equal 80% of the distance and the labels do not overlap', () => {
+  it('should return true if the space between ticks is larger than or equal 50% of the distance and the labels do not overlap', () => {
     ticks = [0, 800, 1600];
     distance = 100;
     measure.withArgs('formatted').returns(50);
     size = 300;
-    scale.withArgs(800).returns(0.3);
+    scale.withArgs(800).returns(0.2);
     scale.withArgs(0).returns(0);
     expect(create()).to.equal(true);
   });
 
-  it('should return false if the space between ticks is smaller than 80% of the distance', () => {
+  it('should return false if the space between ticks is smaller than 50% of the distance', () => {
     ticks = [0, 700, 1400];
     distance = 100;
     measure.withArgs('formatted').returns(50);
     size = 300;
-    scale.withArgs(700).returns(0.2);
+    scale.withArgs(700).returns(0.1);
     scale.withArgs(0).returns(0);
     expect(create()).to.equal(false);
   });

--- a/src/models/tick-model/ticks/index.js
+++ b/src/models/tick-model/ticks/index.js
@@ -6,7 +6,7 @@ export default function getTicks({ scale, explicitType, distance, size, measure,
 
   // 'Nice' if at least one end is implicit (extendable). You can't nice only one end with d3 scale
   const nicing = explicitType !== 'minMax';
-  const count = Math.max(1, Math.round(size / distance));
+  const count = Math.max(2, Math.round(size / distance));
 
   let { ticks: majorTicks, min, max } = tickHelper.getTicksAndMinMax(scale, nicing, count, originalMin, originalMax);
   for (let c = count - 1; c > 0; c--) {

--- a/src/models/tick-model/ticks/tick-helper.js
+++ b/src/models/tick-model/ticks/tick-helper.js
@@ -9,18 +9,36 @@ const tickHelper = {
     let ticks = scale.ticks(count);
     let [min, max] = scale.domain();
 
-    // Corner case: nicing is true and there is only one tick generated. We then have to make it two.
-    if (nicing && ticks.length === 1) {
-      scale.domain([originalMin, originalMax]).nice(2).nice(2);
-      [min, max] = scale.domain();
-      ticks = [min, max];
+    // Corner case: there is only one tick generated. We then have to make at least two.
+    if (ticks.length === 1) {
+      if (nicing) {
+        scale.domain([originalMin, originalMax]).nice(2).nice(2);
+        [min, max] = scale.domain();
+        if (min * max >= 0) {
+          ticks = [min, max];
+        } else if (
+          Math.abs(max) > Math.abs(min) ||
+          (Math.abs(max) === Math.abs(min) && Math.abs(originalMax) > Math.abs(originalMin))
+        ) {
+          min = originalMin;
+          ticks = [0, max];
+        } else {
+          max = originalMax;
+          ticks = [min, 0];
+        }
+      } else {
+        let newCount = 2;
+        while (ticks.length === 1) {
+          ticks = scale.ticks(newCount++);
+        }
+      }
     }
     return { ticks, min, max };
   },
 
   valid({ ticks, scale, distance, size, formatter, measure }) {
-    // It is not valid if the space between two major ticks is smaller than 80% of the distance (i.e. too many ticks)
-    const tolerance = 0.8;
+    // It is not valid if the space between two major ticks is smaller than tolerance times distance (i.e. too many ticks)
+    const tolerance = ticks.length <= 4 ? 0.5 : 0.75;
     const space = (scale(ticks[1]) - scale(ticks[0])) * size;
     if (space < distance * tolerance) {
       return false;


### PR DESCRIPTION
## Description
Fix: https://github.com/qlik-oss/sn-scatter-plot/issues/191, https://github.com/qlik-oss/sn-scatter-plot/issues/179, and https://github.com/qlik-oss/sn-scatter-plot/issues/127

## Verification
- https://github.com/qlik-oss/sn-scatter-plot/issues/191: fixed by making sure zero always shown if it is within the range.
  - Y-direction
   
     https://user-images.githubusercontent.com/70384379/152697358-8d659f9d-e202-4a93-a5fa-bf778fd07ca4.mov

  - X-direction
  
     https://user-images.githubusercontent.com/70384379/152697585-65acaa2c-76e4-4866-92c5-c8368e41db6f.mov



- https://github.com/qlik-oss/sn-scatter-plot/issues/127: fixed by making sure there are always at least two ticks shown when zooming (preferably 3).

   https://user-images.githubusercontent.com/70384379/152697929-e0a6ef14-35b3-4351-bb63-062c6900032a.mov


