### PR TITLE
fix: avoid redundant chart update when show/hide properties panel

### DIFF
--- a/src/hooks/__tests__/use-render.spec.js
+++ b/src/hooks/__tests__/use-render.spec.js
@@ -9,15 +9,18 @@ describe('use-render', () => {
   let models;
   let fn;
   let conditionArray;
+  let chart;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     settings = 'stngs';
     models = {
       chartModel: { command: { update: sandbox.stub() } },
+      dockService: { meta: { chart: { size: { width: 100, height: 200 } } } },
     };
     sandbox.stub(stardust, 'useEffect');
-    create = () => useRender({ settings, models });
+    chart = { element: { clientWidth: 100, clientHeight: 200 } };
+    create = () => useRender({ settings, models, chart });
   });
 
   afterEach(() => {

--- a/src/hooks/use-render.js
+++ b/src/hooks/use-render.js
@@ -1,11 +1,15 @@
 import { useEffect } from '@nebula.js/stardust';
 
-const useRender = ({ settings, models }) => {
+const useRender = ({ settings, models, chart }) => {
   useEffect(() => {
     if (!settings) {
       return;
     }
-
+    const { width, height } = models.dockService.meta.chart.size;
+    const { clientWidth: w, clientHeight: h } = chart?.element;
+    if (w !== Math.round(width) || h !== Math.round(height)) {
+      return;
+    }
     const { chartModel } = models;
     chartModel.command.update({ settings });
   }, [settings]);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function scatterplot(env) {
       const models = useModels({ core, flags });
       const settings = useSettings({ core, models, flags });
 
-      useRender({ settings, models });
+      useRender({ settings, models, chart: core?.chart });
       setupSnapshot({ core, models });
     },
   };


### PR DESCRIPTION
## Description
- Issue: https://github.com/qlik-oss/sn-scatter-plot/issues/126
- Root cause: every time you press on the Edit Sheet/Done Editting button, the scatter plot calls `chart.update` inside `use-render.js` twice, due to the docking/undocking of the Properties Panel. In the first update, the chart element size is different from the chart docking size (the element is lagging behind the docking area). In the second update, they are the same, and animations will kick in. The first update is redundant and should be remove to avoid unnecessary transitions when showing/hiding Properties Panel.
## Verification
- Point data
  - Before fix
  
  https://user-images.githubusercontent.com/70384379/152879692-83ceada7-eb12-4a97-8381-4418d14e6aad.mov


  - After  

  https://user-images.githubusercontent.com/70384379/152879531-ab32a127-b16a-4b98-b905-f54fcb7fc1ae.mov




- Bin data
  - Before fix 

  https://user-images.githubusercontent.com/70384379/152879828-f9c20c2a-fab8-45c0-a806-d17da7fac2da.mov


  - After

  https://user-images.githubusercontent.com/70384379/152879197-c0fd0af5-bdbb-4adf-b478-86b707fa4b79.mov

