### PR TITLE
fix: grid lines adjust lower limit

### DIFF
--- a/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
+++ b/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
@@ -43,17 +43,57 @@ describe('getTicksAndMinMax', () => {
     expect(nicedScale.nice).to.not.have.been.called;
   });
 
-  it('should call nice with arg 2 if nicing is true and ticks has one element', () => {
-    nicing = true;
-    count = 1;
-    scale.ticks.returns([0]);
-    scale.domain.withArgs().returns([-100, 100]);
-    const domainedScale = { nice: sandbox.stub() };
-    domainedScale.nice.returns(nicedScale);
-    scale.domain.withArgs([-10, 190]).returns(domainedScale);
-    create();
-    expect(nicedScale.nice.withArgs(1)).to.have.been.calledOnce;
-    expect(nicedScale.nice.withArgs(2)).to.have.been.calledOnce;
+  describe('corner case: only one tick generated', () => {
+    beforeEach(() => {
+      count = 1;
+    });
+
+    describe('nicing is true', () => {
+      let domainedScale;
+      beforeEach(() => {
+        nicing = true;
+        domainedScale = { nice: sandbox.stub() };
+        domainedScale.nice.returns(nicedScale);
+      });
+
+      it('should return correct ticks and min max when min-max range does not include zero', () => {
+        scale.ticks.returns([200]);
+        scale.domain.withArgs().returns([100, 300]);
+        scale.domain.withArgs([-10, 190]).returns(domainedScale);
+        expect(create()).to.deep.equal({ ticks: [100, 300], min: 100, max: 300 });
+      });
+
+      it('should return correct ticks and min max when min-max range include zero and abs(max) >= abs(min)', () => {
+        scale.ticks.returns([100]);
+        scale.domain.withArgs().returns([-300, 300]);
+        originalMin = -200;
+        originalMax = 280;
+        scale.domain.withArgs([-200, 280]).returns(domainedScale);
+        expect(create()).to.deep.equal({ ticks: [0, 300], min: -200, max: 300 });
+      });
+
+      it('should return correct ticks and min max when min-max range include zero and abs(max) < abs(min)', () => {
+        scale.ticks.returns([-100]);
+        scale.domain.withArgs().returns([-200, 100]);
+        originalMin = -180;
+        originalMax = 80;
+        scale.domain.withArgs([-180, 80]).returns(domainedScale);
+        expect(create()).to.deep.equal({ ticks: [-200, 0], min: -200, max: 80 });
+      });
+    });
+
+    describe('nicing is false', () => {
+      beforeEach(() => {
+        nicing = false;
+      });
+
+      it('should return corect ticks', () => {
+        scale.ticks.withArgs(1).returns([-100]);
+        scale.ticks.withArgs(2).returns([-200, 0]);
+        scale.domain.withArgs().returns([-200, 100]);
+        expect(create()).to.deep.equal({ ticks: [-200, 0], min: -200, max: 100 });
+      });
+    });
   });
 });
 
@@ -94,6 +134,15 @@ describe('valid', () => {
     distance = 100;
     measure.withArgs('formatted').returns(50);
     size = 300;
+    scale.withArgs(700).returns(0.1);
+    scale.withArgs(0).returns(0);
+    expect(create()).to.equal(false);
+  });
+
+  it('should return false if the space between ticks is smaller than 80% of the distance', () => {
+    ticks = [0, 700, 1400, 2100, 2800];
+    distance = 100;
+    size = 799;
     scale.withArgs(700).returns(0.1);
     scale.withArgs(0).returns(0);
     expect(create()).to.equal(false);

--- a/src/models/tick-model/ticks/tick-helper.js
+++ b/src/models/tick-model/ticks/tick-helper.js
@@ -38,7 +38,7 @@ const tickHelper = {
 
   valid({ ticks, scale, distance, size, formatter, measure }) {
     // It is not valid if the space between two major ticks is smaller than tolerance times distance (i.e. too many ticks)
-    const tolerance = ticks.length <= 4 ? 0.5 : 0.75;
+    const tolerance = ticks.length <= 4 ? 0.5 : 0.8;
     const space = (scale(ticks[1]) - scale(ticks[0])) * size;
     if (space < distance * tolerance) {
       return false;


### PR DESCRIPTION
## Description
After comparing with the old chart, I realized that the lower limit of 75% of the nominal grid size is a bit too tight.