### PR TITLE
fix: ticks when snapshot is locked

### DIFF
--- a/src/models/tick-model/index.js
+++ b/src/models/tick-model/index.js
@@ -29,7 +29,7 @@ export default function createTickModel({
       spacing = layoutService.getLayoutValue('yAxis.spacing', 1);
     }
 
-    const size = tickHelper.getSize(dockService, chartModel, chart, dimension);
+    const size = tickHelper.getSize(dockService, chartModel, chart, dimension, layoutService);
     const distance = tickHelper.getDistance(spacing);
 
     // Get the measureText function from renderer

--- a/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
+++ b/src/models/tick-model/ticks/__tests__/tick-helper.spec.js
@@ -206,6 +206,7 @@ describe('getSize', () => {
   let chartModel;
   let chart;
   let dimension;
+  let layoutService;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -213,11 +214,18 @@ describe('getSize', () => {
     sandbox.stub(KEYS, 'COMPONENT').value({ POINT: 'point-component', HEAT_MAP: 'heat-map' });
     chart = { component: sandbox.stub() };
     chartModel = { query: { isPrelayout: sandbox.stub() } };
-    create = () => tickHelper.getSize(dockService, chartModel, chart, dimension);
+    layoutService = { meta: { isSnapshot: undefined } };
+    create = () => tickHelper.getSize(dockService, chartModel, chart, dimension, layoutService);
   });
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it('should return correct size if it is snapshot', () => {
+    layoutService.meta.isSnapshot = true;
+    dimension = 'width';
+    expect(create()).to.equal(100);
   });
 
   it('should return correct size if prelayout is true and dimension is width', () => {

--- a/src/models/tick-model/ticks/tick-helper.js
+++ b/src/models/tick-model/ticks/tick-helper.js
@@ -63,8 +63,8 @@ const tickHelper = {
     }
   },
 
-  getSize(dockService, chartModel, chart, dimension) {
-    if (chartModel.query.isPrelayout()) {
+  getSize(dockService, chartModel, chart, dimension, layoutService) {
+    if (layoutService.meta.isSnapshot || chartModel.query.isPrelayout()) {
       return dockService.meta.chart.size[dimension];
     }
     const pointDimension = chart.component(KEYS.COMPONENT.POINT)?.rect.computedPhysical[dimension];


### PR DESCRIPTION
## Description
- Fix #243 
- Root cause: currently the chart size upon which the ticks are calculated are the actual size. This should be the logical size (from dockService) when the chart is in snapshot mode.
## Verification
- Before fix: see #243
- After fix

https://user-images.githubusercontent.com/70384379/153229920-a3b98124-25a7-4faf-9519-3afe92e2c166.mov


