### PR TITLE
fix: tick model generate decent granularity

### DIFF
--- a/src/hooks/view-state.js
+++ b/src/hooks/view-state.js
@@ -1,5 +1,3 @@
-import KEYS from '../constants/keys';
-
 /**
  * Get relative dataView from:
  * - snapshot data
@@ -12,12 +10,6 @@ export function updateViewState({ viewState, viewStateOptions = {}, models }) {
   const source = layoutService.meta.isSnapshot
     ? layoutService.getLayoutValue('snapshotData.content.chartData', {})
     : viewStateOptions;
-
-  const formatters = {
-    x: chartModel.query.getFormatter(KEYS.FIELDS.X),
-    y: chartModel.query.getFormatter(KEYS.FIELDS.Y),
-  };
-  tickModel.command.updateFormatters(formatters);
 
   const viewHandler = chartModel.query.getViewHandler();
   if (viewHandler.getMeta().isHomeState) {

--- a/src/models/chart-model/__tests__/format-pattern-from-range.spec.js
+++ b/src/models/chart-model/__tests__/format-pattern-from-range.spec.js
@@ -1,0 +1,59 @@
+import * as KEYS from '../../../constants/keys';
+import getFormatPatternFromRange from '../format-pattern-from-range';
+
+describe('getFormatPatternFromRange', () => {
+  let sandbox;
+  let create;
+  let scaleName;
+  let viewHandler;
+  let layoutService;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(KEYS, 'default').value({ SCALE: { X: 'x', Y: 'y' } });
+    viewHandler = { getMeta: sandbox.stub() };
+    layoutService = { getHyperCubeValue: sandbox.stub() };
+    create = () => getFormatPatternFromRange(scaleName, viewHandler, layoutService);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return false if cannot get min or max', () => {
+    scaleName = 'x';
+    viewHandler.getMeta.returns({ homeStateDataView: { xAxisMin: 800000000 } });
+    expect(create()).to.equal(false);
+  });
+
+  it('should correct format pattern when, case 1: xRange = [800M, 801M], thousand delimiter is undefined', () => {
+    scaleName = 'x';
+    viewHandler.getMeta.returns({ homeStateDataView: { xAxisMin: 800000000, xAxisMax: 801000000 } });
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qThou').returns(undefined);
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qDec').returns('d');
+    expect(create()).to.equal('0d####');
+  });
+
+  it('should correct format pattern when, case 2: xRange = [800M, 800M]', () => {
+    scaleName = 'x';
+    viewHandler.getMeta.returns({ homeStateDataView: { xAxisMin: 800000000, xAxisMax: 800000000 } });
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qDec').returns('.');
+    expect(create()).to.equal('0.##');
+  });
+
+  it('should correct format pattern when, case 3: yRange = [0.001, 0.081]', () => {
+    scaleName = 'y';
+    viewHandler.getMeta.returns({ homeStateDataView: { yAxisMin: 0.001, yAxisMax: 0.081 } });
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qThou').returns(',');
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qDec').returns('.');
+    expect(create()).to.equal('#,##0.###');
+  });
+
+  it('should correct format pattern when, case 4: yRange = [0.01, 10.01]', () => {
+    scaleName = 'y';
+    viewHandler.getMeta.returns({ homeStateDataView: { yAxisMin: 0.01, yAxisMax: 10.01 } });
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qThou').returns(',');
+    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qDec').returns('.');
+    expect(create()).to.equal('#,##0.#');
+  });
+});

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -1,5 +1,6 @@
 import * as KEYS from '../../../constants/keys';
 import createChartModel from '..';
+import * as getFormatPatternFromRange from '../format-pattern-from-range';
 import * as createViewHandler from '../../../view-handler';
 
 describe('chart-model', () => {
@@ -10,8 +11,6 @@ describe('chart-model', () => {
   let layoutService;
   let colorService;
   let trendLinesService;
-  let picassoInstance;
-  let picassoDataFn;
   let colorModelDataFn;
   let create;
   let viewHandler;
@@ -81,10 +80,7 @@ describe('chart-model', () => {
     colorService = {
       getData: colorModelDataFn,
     };
-    picassoDataFn = sandbox.stub().returns('correct dataset');
-    picassoInstance = {
-      data: () => picassoDataFn,
-    };
+    sandbox.stub(getFormatPatternFromRange, 'default');
     create = () =>
       createChartModel({
         chart,
@@ -92,7 +88,6 @@ describe('chart-model', () => {
         layoutService,
         colorService,
         trendLinesService,
-        picasso: picassoInstance,
         viewState,
         extremumModel,
         dataHandler,
@@ -107,17 +102,6 @@ describe('chart-model', () => {
     expect(create()).to.have.all.keys(['query', 'command']);
   });
 
-  it('should prepare dataset properly', () => {
-    create();
-    expect(picassoDataFn).to.have.been.calledWith({
-      key: 'dm',
-      data: hyperCube,
-      config: {
-        localeInfo,
-      },
-    });
-  });
-
   describe('query', () => {
     it('should have correct properties', () => {
       expect(create().query).to.have.all.keys([
@@ -126,7 +110,7 @@ describe('chart-model', () => {
         'getDataHandler',
         'getLocaleInfo',
         'isPrelayout',
-        'getFormatter',
+        'getFormatPattern',
         'miniChartEnabled',
       ]);
     });
@@ -161,15 +145,10 @@ describe('chart-model', () => {
       });
     });
 
-    describe('getFormatter', () => {
-      it('should return correct getFormatter value', () => {
-        picassoDataFn.returns({
-          field: sandbox
-            .stub()
-            .withArgs('x')
-            .returns({ formatter: sandbox.stub().returns('x-formatter') }),
-        });
-        expect(create().query.getFormatter('x')).to.deep.equal('x-formatter');
+    describe('getFormatPattern', () => {
+      it('should call getFormatPatternFromRange', () => {
+        create().query.getFormatPattern('x');
+        expect(getFormatPatternFromRange.default).to.have.been.calledOnce;
       });
     });
   });

--- a/src/models/chart-model/format-pattern-from-range.js
+++ b/src/models/chart-model/format-pattern-from-range.js
@@ -16,12 +16,7 @@ export default function getFormatPatternFromRange(scaleName, viewHandler, layout
   const maxMagnitude = Math.floor(Math.log10(Math.abs(max)));
   const minDecimals = Math.min(Math.abs(minMagnitude), Math.abs(maxMagnitude));
   const range = Math.abs(max - min);
-  let reduceBy;
-  const rangeMagnitude = Number(
-    Number(range / 50)
-      .toExponential()
-      .split('e')[1]
-  );
+  const rangeMagnitude = Math.floor(Math.log10(Math.abs(range / 50)));
 
   let nDecimals = Math.abs(rangeMagnitude);
 
@@ -32,6 +27,7 @@ export default function getFormatPatternFromRange(scaleName, viewHandler, layout
     return '0'.concat(decimalDelimiter, '##');
   }
 
+  let reduceBy;
   if (rangeMagnitude >= 0) {
     nDecimals = Math.max(2, minDecimals - rangeMagnitude);
   } else {

--- a/src/models/chart-model/format-pattern-from-range.js
+++ b/src/models/chart-model/format-pattern-from-range.js
@@ -1,0 +1,51 @@
+import KEYS from '../../constants/keys';
+
+export default function getFormatPatternFromRange(scaleName, viewHandler, layoutService) {
+  let min;
+  let max;
+  if (scaleName === KEYS.SCALE.X) {
+    ({ xAxisMin: min, xAxisMax: max } = viewHandler.getMeta().homeStateDataView);
+  } else {
+    ({ yAxisMin: min, yAxisMax: max } = viewHandler.getMeta().homeStateDataView);
+  }
+  if (!min || !max) {
+    return false;
+  }
+  let p = '';
+  const minMagnitude = Number(Number(min).toExponential().split('e')[1]);
+  const maxMagnitude = Number(Number(max).toExponential().split('e')[1]);
+  const minDecimals = Math.min(Math.abs(minMagnitude), Math.abs(maxMagnitude));
+  const range = Math.abs(max - min);
+  let reduceBy;
+  const rangeMagnitude = Number(
+    Number(range / 50)
+      .toExponential()
+      .split('e')[1]
+  );
+
+  let nDecimals = Math.abs(rangeMagnitude);
+
+  const field = scaleName === KEYS.SCALE.X ? 'qMeasureInfo.0' : 'qMeasureInfo.1';
+  const thousandDelimiter = layoutService.getHyperCubeValue(`${field}.qNumFormat.qThou`, false);
+  const decimalDelimiter = layoutService.getHyperCubeValue(`${field}.qNumFormat.qDec`, '.');
+  if (range === 0) {
+    return '0'.concat(decimalDelimiter, '##');
+  }
+
+  if (rangeMagnitude >= 0) {
+    nDecimals = Math.max(2, minDecimals - rangeMagnitude);
+  } else {
+    reduceBy = (minDecimals - (minDecimals % 3)) * (maxMagnitude < 0 ? 1 : -1);
+    nDecimals -= reduceBy;
+  }
+
+  p += thousandDelimiter ? '#'.concat(thousandDelimiter, '##0') : '0';
+  if (nDecimals) {
+    p += decimalDelimiter;
+    for (let i = 0; i < nDecimals; i++) {
+      p += '#';
+    }
+  }
+
+  return p;
+}

--- a/src/models/chart-model/format-pattern-from-range.js
+++ b/src/models/chart-model/format-pattern-from-range.js
@@ -8,12 +8,12 @@ export default function getFormatPatternFromRange(scaleName, viewHandler, layout
   } else {
     ({ yAxisMin: min, yAxisMax: max } = viewHandler.getMeta().homeStateDataView);
   }
-  if (!min || !max) {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
     return false;
   }
   let p = '';
-  const minMagnitude = Number(Number(min).toExponential().split('e')[1]);
-  const maxMagnitude = Number(Number(max).toExponential().split('e')[1]);
+  const minMagnitude = Math.floor(Math.log10(Math.abs(min)));
+  const maxMagnitude = Math.floor(Math.log10(Math.abs(max)));
   const minDecimals = Math.min(Math.abs(minMagnitude), Math.abs(maxMagnitude));
   const range = Math.abs(max - min);
   let reduceBy;

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -1,12 +1,12 @@
 import KEYS from '../../constants/keys';
 import createViewHandler from '../../view-handler';
+import getFormatPatternFromRange from './format-pattern-from-range';
 
 export default function createChartModel({
   chart,
   localeInfo,
   layoutService,
   colorService,
-  picasso,
   viewState,
   extremumModel,
   dataHandler,
@@ -80,8 +80,6 @@ export default function createChartModel({
       },
     ];
   };
-
-  const dataset = picasso.data('q')(mainConfig);
 
   function updatePartial() {
     viewHandler.setMeta({ updateWithSettings: false });
@@ -175,7 +173,7 @@ export default function createChartModel({
       getViewHandler: () => viewHandler,
       getDataHandler: () => dataHandler,
       getLocaleInfo: () => localeInfo,
-      getFormatter: (fieldName) => dataset.field(fieldName).formatter(),
+      getFormatPattern: (scaleName) => getFormatPatternFromRange(scaleName, viewHandler, layoutService),
       isPrelayout: () => state.isPrelayout,
       miniChartEnabled,
     },

--- a/src/models/tick-model/index.js
+++ b/src/models/tick-model/index.js
@@ -1,5 +1,4 @@
 import { scaleLinear } from 'd3-scale';
-import extend from 'extend';
 import picasso from 'picasso.js';
 import KEYS from '../../constants/keys';
 import getTicks from './ticks';
@@ -45,16 +44,27 @@ export default function createTickModel({
     return { min, max, explicitType, distance, size, measure };
   }
 
-  const formatters = {
-    x: chartModel.query.getFormatter(KEYS.FIELDS.X),
-    y: chartModel.query.getFormatter(KEYS.FIELDS.Y),
+  const formatPatterns = {
+    [KEYS.SCALE.X]: undefined,
+    [KEYS.SCALE.Y]: undefined,
   };
 
   function resolve(axis, prop) {
+    if (!formatPatterns[axis]) {
+      const field = axis === KEYS.SCALE.X ? 'qMeasureInfo.0' : 'qMeasureInfo.1';
+      const isAutoFormat = layoutService.getHyperCubeValue(`${field}.qIsAutoFormat`, false);
+      if (isAutoFormat) {
+        formatPatterns[axis] = chartModel.query.getFormatPattern(axis);
+      }
+    }
+
+    if (formatPatterns[axis]) {
+      chart.formatters()[axis].pattern(formatPatterns[axis]);
+    }
+
     const { min, max, explicitType, distance, size, measure } = getChartProperties(axis);
     const scale = scaleLinear().domain([min, max]);
-    const formatter = axis === KEYS.SCALE.X ? formatters.x : formatters.y;
-    const tickObject = getTicks({ scale, explicitType, distance, size, measure, formatter });
+    const tickObject = getTicks({ scale, explicitType, distance, size, measure, formatter: chart.formatters()[axis] });
     return prop === 'ticks' ? tickObject.ticks : tickObject.minMax;
   }
 
@@ -64,12 +74,6 @@ export default function createTickModel({
       getYTicks: () => resolve(KEYS.SCALE.Y, 'ticks'),
       getXMinMax: () => resolve(KEYS.SCALE.X, 'minMax'),
       getYMinMax: () => resolve(KEYS.SCALE.Y, 'minMax'),
-    },
-
-    command: {
-      updateFormatters: (newFormatters) => {
-        extend(true, formatters, newFormatters);
-      },
     },
   };
 }


### PR DESCRIPTION
## Description
- Fix: #248 
- Root cause: default autoFormat formatter of Picasso only generates a maximum of 2 decimal digits, which is not enough when the range is very narrow.
- The fix: create a format pattern from range, allowing as many decimal digits as necessary. Assign this pattern for formatters of X-axis and Y-axis.
- Files changed:
  - [src/hooks/view-state.js](https://github.com/qlik-oss/sn-scatter-plot/pull/254/files#diff-0bbff74d9a79fd8c4daab7f9a562ef14b05866ae75e72aefbf9037bc3821c8ef): in the new code, in tick model, we get the formatters directly from chart. Therefore, there's no need to update tick-model formatters.
  - [src/models/chart-model/format-pattern-from-range.js](https://github.com/qlik-oss/sn-scatter-plot/pull/254/files#diff-f2d4aa39fecd085b9c2872e38df1356bb1eaf4d23004871a940a6477c73a0d61): create a format pattern based on the homestate data view range.
  - [src/models/chart-model/index.js](src/models/chart-model/index.js): in the new code, in tick model, we get the formatters directly from chart. Therefore, there's no need to getFormatter from chart model. Instead, we need an API function for getting format pattern based on range.
  - [src/models/tick-model/index.js](src/models/tick-model/index.js): main code change is in here. First, we can get rid of the closure object formatters, since we now get formatters directly from chat, and also there is not need for the `command.updateFormatters` API function. In the `resolve` function, we only get the format pattern once and only when autoFormat is true. However, we need to update the pattern for the chart's x and y formatters everytime we need to resolve new ticks (and display new tick labels on axes) because new formatters are constructed every time the chart is updated.
## Verification
![image](https://user-images.githubusercontent.com/70384379/153729742-633ca839-6a92-49bd-b162-62ad3d66241b.png)
