### PR TITLE
fix: update api specs

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -201,6 +201,11 @@
               "defaultValue": 5,
               "type": "number"
             },
+            "queryLevel": {
+              "description": "Resolution settings for compressed data.",
+              "defaultValue": 6,
+              "type": "number"
+            },
             "rangeBubbleSizes": {
               "description": "Bubble sizes. Represented as an array of two integers where the first index is the from-size and the second the to-size. From-size needs to be smaller. Only applicable when there is a third neasure.",
               "defaultValue": "5",
@@ -493,6 +498,13 @@
               ],
               "type": "any"
             }
+          }
+        },
+        "trendLines": {
+          "description": "Array of trend lines",
+          "kind": "array",
+          "items": {
+            "type": "any"
           }
         },
         "version": {

--- a/src/qae/object-definition.js
+++ b/src/qae/object-definition.js
@@ -176,6 +176,12 @@ const objectDefinition = () => {
        * @default 5
        */
       rangeBubbleSizes: [2, 8],
+      /**
+       * Resolution settings for compressed data.
+       * @type {number}
+       * @default 6
+       */
+      queryLevel: 6,
     },
     /**
      * Set to enable or disable navigation menu.
@@ -281,6 +287,11 @@ const objectDefinition = () => {
        */
       refLinesY: [],
     },
+    /**
+     * Array of trend lines
+     * @type {array}
+     */
+    trendLines: [],
     /**
      * Show visualization details toggle
      * @type {boolean=}


### PR DESCRIPTION
Add `queryLevel` and `trendLines`