### PR TITLE
fix: add sanity check for formatter without pattern

### DIFF
--- a/src/models/tick-model/index.js
+++ b/src/models/tick-model/index.js
@@ -60,7 +60,10 @@ export default function createTickModel({
     }
 
     if (formatPatterns[axis]) {
-      chart.formatters()[axis].pattern(formatPatterns[axis]);
+      const formatters = chart.formatters();
+      if (typeof formatters[axis].pattern === 'function') {
+        formatters[axis].pattern(formatPatterns[axis]);
+      }
     }
 
     const { min, max, explicitType, distance, size, measure } = getChartProperties(axis);


### PR DESCRIPTION
To fix https://jira.qlikdev.com/browse/QB-9507 caused by https://github.com/qlik-oss/sn-scatter-plot/pull/254