### PR TITLE
fix: ref-line-label hasEngineFormat should handle when valueLabel is not a string (unit tests)

### DIFF
--- a/src/picasso-components/ref-line-labels/internal/__tests__/label-helper.spec.js
+++ b/src/picasso-components/ref-line-labels/internal/__tests__/label-helper.spec.js
@@ -217,6 +217,14 @@ describe('hasEngineFormat', () => {
     expect(result).to.deep.equal(true);
   });
 
+  it('should handle when valueLabel is not a string', () => {
+    value = 1234;
+    valueLabel = 1234;
+    localeInfo = { qDecimalSep: '.', qThousandSep: ',' };
+    const result = hasEngineFormat(value, valueLabel, localeInfo);
+    expect(result).to.deep.equal(false);
+  });
+
   it('should return false, if value and valueLabel are defined and are not the same, localeInfo is defined, but valueLabel contains only digits, e, +, -, decimal separator, or thoudsand separtor.', () => {
     value = 1234;
     valueLabel = '1*234$567e6';


### PR DESCRIPTION
Add unit tests for:
- https://github.com/qlik-oss/sn-scatter-plot/pull/271