### PR TITLE
fix: screen reader instructions added

### DIFF
--- a/src/picasso-components/react-components/data-title-component.jsx
+++ b/src/picasso-components/react-components/data-title-component.jsx
@@ -58,12 +58,12 @@ const FadeButton = (
     {children}
   </Button>
 );
-
+// added role="list" to avoid the reading as button for screen readers
 export default function createDataTitileComp() {
   function HyperDataItem({ title, selected, onClick }) {
     const localDir = rtlUtils.detectTextDirection(title);
     return (
-      <ListItem role="list" button onClick={onClick} style={{ textAlign: 'start' }}>
+      <ListItem role="list" button onClick={onClick} style={{ textAlign: 'start' }}> 
         <ListItemIcon style={{ minWidth: 32 }}>
           <SVGIcon d={selected ? ICONS.TICK.d : ''} />
         </ListItemIcon>

--- a/src/picasso-components/react-components/data-title-component.jsx
+++ b/src/picasso-components/react-components/data-title-component.jsx
@@ -63,7 +63,7 @@ export default function createDataTitileComp() {
   function HyperDataItem({ title, selected, onClick }) {
     const localDir = rtlUtils.detectTextDirection(title);
     return (
-      <ListItem button onClick={onClick} style={{ textAlign: 'start' }}>
+      <ListItem role="list" button onClick={onClick} style={{ textAlign: 'start' }}>
         <ListItemIcon style={{ minWidth: 32 }}>
           <SVGIcon d={selected ? ICONS.TICK.d : ''} />
         </ListItemIcon>
@@ -92,7 +92,7 @@ export default function createDataTitileComp() {
           style: { minWidth: '250px', maxHeight: '300px' },
         }}
       >
-        <List dense dir={dir} component="nav">
+        <List dense dir={dir} aria-label="use the tab keys to navigate between the options" component="nav">
           <HyperDataItem title={current} selected onClick={onClose} />
           {items}
         </List>
@@ -245,8 +245,10 @@ export default function createDataTitileComp() {
         style.minWidth = minWidth;
       }
       const dir = rtlUtils.detectTextDirection(titleData.text);
+      const instruction = `Currently ${titleData.text} is selcted. Click to expand or press enter key to open the list`;
       const label = (
         <FadeButton
+          aria-label={instruction}
           style={style}
           onClick={disabledLabel ? undefined : onClick}
           title={titleData.text}


### PR DESCRIPTION
## Description

This PR contains fixes of two defects QB-8718 and QB-9133

QB-8718 - on chart popover, now its reading as button , instead it should read as "list item"

QB-9133 - there there is no proper instruction for user, so there must be proper instruction for user about this drop down (like on click what happens)

## Fixes

Added `aria-label`
Tested on NVDA screen reader.

[Video link](https://jira.qlikdev.com/secure/attachment/279063/279063_qb_8718_qb_9133.mp4)