### PR TITLE
refactor: use data instead of args properties

### DIFF
--- a/src/ext/property-definition/__tests__/index.spec.js
+++ b/src/ext/property-definition/__tests__/index.spec.js
@@ -363,14 +363,15 @@ describe('property panel definition', () => {
           describe('convertFunctions', () => {
             let get;
             let set;
-            let args;
+            let data;
             const sandbox = sinon.createSandbox();
             const definition = { type: 'string' };
             const getter = (type) => type;
+            const args = {};
 
             beforeEach(() => {
               sandbox.stub(chartModules, 'setValue');
-              args = { properties: { xAxis: { autoMinMax: true, min: '10' } } };
+              data = { xAxis: { autoMinMax: true, min: '10' } };
               ({ get, set } = def.items.settings.items.xAxis.items.startAt.convertFunctions);
             });
 
@@ -380,25 +381,17 @@ describe('property panel definition', () => {
 
             describe('get', () => {
               it('should convert value to lowest when is autoMinMax', () => {
-                expect(get(getter, definition, args)).to.equal('lowest');
+                expect(get(getter, definition, args, data)).to.equal('lowest');
               });
 
               it('should convert value to zero when is not autoMinMax, type is min and min is 0', () => {
-                args = {
-                  properties: {
-                    xAxis: { autoMinMax: false, minMax: 'min', min: 0 },
-                  },
-                };
-                expect(get(getter, definition, args)).to.equal('zero');
+                data = { xAxis: { autoMinMax: false, minMax: 'min', min: 0 } };
+                expect(get(getter, definition, args, data)).to.equal('zero');
               });
 
               it('should return value from getter when is not autoMinMax and type is max', () => {
-                args = {
-                  properties: {
-                    xAxis: { autoMinMax: false, minMax: 'max', min: 0 },
-                  },
-                };
-                expect(get(getter, definition, args)).to.equal('string');
+                data = { xAxis: { autoMinMax: false, minMax: 'max', min: 0 } };
+                expect(get(getter, definition, args, data)).to.equal('string');
               });
             });
 
@@ -603,15 +596,16 @@ describe('property panel definition', () => {
           describe('convertFunctions', () => {
             let get;
             let set;
-            let args;
+            let data;
 
             const sandbox = sinon.createSandbox();
             const definition = { type: 'string' };
             const getter = (type) => type;
+            const args = {};
 
             beforeEach(() => {
               sandbox.stub(chartModules, 'setValue');
-              args = { properties: { yAxis: { autoMinMax: true, min: '10' } } };
+              data = { yAxis: { autoMinMax: true, min: '10' } };
               ({ get, set } = def.items.settings.items.yAxis.items.startAt.convertFunctions);
             });
 
@@ -621,25 +615,17 @@ describe('property panel definition', () => {
 
             describe('get', () => {
               it('should convert value to lowest when is autoMinMax', () => {
-                expect(get(getter, definition, args)).to.equal('lowest');
+                expect(get(getter, definition, args, data)).to.equal('lowest');
               });
 
               it('should convert value to zero when is not autoMinMax, type is min and min is 0', () => {
-                args = {
-                  properties: {
-                    yAxis: { autoMinMax: false, minMax: 'min', min: 0 },
-                  },
-                };
-                expect(get(getter, definition, args)).to.equal('zero');
+                data = { yAxis: { autoMinMax: false, minMax: 'min', min: 0 } };
+                expect(get(getter, definition, args, data)).to.equal('zero');
               });
 
               it('should return value from getter when is not autoMinMax and type is max', () => {
-                args = {
-                  properties: {
-                    yAxis: { autoMinMax: false, minMax: 'max', min: 0 },
-                  },
-                };
-                expect(get(getter, definition, args)).to.equal('string');
+                data = { yAxis: { autoMinMax: false, minMax: 'max', min: 0 } };
+                expect(get(getter, definition, args, data)).to.equal('string');
               });
             });
 

--- a/src/ext/property-definition/index.js
+++ b/src/ext/property-definition/index.js
@@ -87,10 +87,8 @@ export default function propertyDefinition(env) {
       labels: {
         items: {
           header: {
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions.length && args.properties.qHyperCubeDef.qMeasures.length >= 2
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions.length && props.qHyperCubeDef.qMeasures.length >= 2;
             },
           },
           labels: {
@@ -98,17 +96,15 @@ export default function propertyDefinition(env) {
             ref: 'labels.mode',
             type: 'number',
             translation: 'Simple.Label.Show',
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions.length && args.properties.qHyperCubeDef.qMeasures.length >= 2
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions.length && props.qHyperCubeDef.qMeasures.length >= 2;
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.labels.mode;
+              get(getter, def, args, data) {
+                return data.labels.mode;
               },
-              set(value, setter, def, args) {
-                args.properties.labels.mode = value ? 1 : 0;
+              set(value, setter, def, args, data) {
+                data.labels.mode = value ? 1 : 0;
               },
             },
           },
@@ -118,17 +114,15 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.XAxis.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions.length && args.properties.qHyperCubeDef.qMeasures.length >= 2
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions.length && props.qHyperCubeDef.qMeasures.length >= 2;
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.xAxis.show === 'labels' || args.properties.xAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.xAxis.show === 'labels' || data.xAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.xAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.xAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -138,17 +132,15 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.YAxis.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions.length && args.properties.qHyperCubeDef.qMeasures.length >= 2
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions.length && props.qHyperCubeDef.qMeasures.length >= 2;
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.yAxis.show === 'labels' || args.properties.yAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.yAxis.show === 'labels' || data.yAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.yAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.yAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -469,8 +461,8 @@ export default function propertyDefinition(env) {
             ],
             defaultValue: 'lowest',
             convertFunctions: {
-              get(getter, definition, args) {
-                const { autoMinMax, minMax, min } = args.properties?.xAxis || {};
+              get(getter, definition, args, data) {
+                const { autoMinMax, minMax, min } = data?.xAxis || {};
                 if (autoMinMax === true) {
                   return 'lowest';
                 }
@@ -602,8 +594,8 @@ export default function propertyDefinition(env) {
             ],
             defaultValue: 'lowest',
             convertFunctions: {
-              get(getter, definition, args) {
-                const { autoMinMax, minMax, min } = args.properties?.yAxis || {};
+              get(getter, definition, args, data) {
+                const { autoMinMax, minMax, min } = data?.yAxis || {};
                 if (autoMinMax === true) {
                   return 'lowest';
                 }


### PR DESCRIPTION
For auto chart to show inner object properties in simple mode, we have to pass in inner object properties to properties panel. So replace the places where using args.properties(auto chart properties) to props(data)

https://user-images.githubusercontent.com/25456307/172373636-0105c8c1-ee2f-4317-bb7a-2a2615b765c5.mov


