### PR TITLE
fix(analytic-creation): default label for resetting in simple edit mode

### DIFF
--- a/src/ext/property-definition/index.js
+++ b/src/ext/property-definition/index.js
@@ -96,6 +96,7 @@ export default function propertyDefinition(env) {
             ref: 'labels.mode',
             type: 'number',
             translation: 'Simple.Label.Show',
+            defaultValue: 1,
             show(props) {
               return props.qHyperCubeDef.qDimensions.length && props.qHyperCubeDef.qMeasures.length >= 2;
             },


### PR DESCRIPTION
To support this PR: https://github.com/qlik-trial/analytics/pull/228