### PR TITLE
fix: correct navigation panel show value

### DIFF
--- a/src/picasso-definition/components/navigation-panel/__tests__/index.spec.js
+++ b/src/picasso-definition/components/navigation-panel/__tests__/index.spec.js
@@ -52,6 +52,11 @@ describe('createNavigationPanel', () => {
 
   describe('the returned buttons', () => {
     describe('UP', () => {
+      it('should have show as false if navigation is undefined', () => {
+        layoutService.getLayoutValue.returns(undefined);
+        expect(create()[0].show).to.be.false;
+      });
+
       it('should have correct callback', () => {
         chartModel.query.getViewHandler.returns('vh');
         create()[0].settings.callback();
@@ -60,6 +65,11 @@ describe('createNavigationPanel', () => {
     });
 
     describe('LEFT', () => {
+      it('should have show as false if navigation is undefined', () => {
+        layoutService.getLayoutValue.returns(undefined);
+        expect(create()[1].show).to.be.false;
+      });
+
       it('should have correct callback', () => {
         chartModel.query.getViewHandler.returns('vh');
         create()[1].settings.callback();
@@ -106,6 +116,11 @@ describe('createNavigationPanel', () => {
     });
 
     describe('RIGHT', () => {
+      it('should have show as false if navigation is undefined', () => {
+        layoutService.getLayoutValue.returns(undefined);
+        expect(create()[3].show).to.be.false;
+      });
+
       it('should have correct disabled function', () => {
         expect(create()[3].settings.disabled()).to.equal(false);
       });
@@ -129,6 +144,11 @@ describe('createNavigationPanel', () => {
     });
 
     describe('DOWN', () => {
+      it('should have show as false if navigation is undefined', () => {
+        layoutService.getLayoutValue.returns(undefined);
+        expect(create()[4].show).to.be.false;
+      });
+
       it('should have correct callback', () => {
         chartModel.query.getViewHandler.returns('vh');
         create()[4].settings.callback();

--- a/src/picasso-definition/components/navigation-panel/index.js
+++ b/src/picasso-definition/components/navigation-panel/index.js
@@ -12,7 +12,7 @@ export default function createNavigationPanel({ layoutService, chartModel, chart
   const viewHandler = chartModel.query.getViewHandler();
   const { rtl, translator, model, constraints } = context;
   const { element } = chart;
-  const navigation = layoutService.getLayoutValue('navigation');
+  const navigation = !!layoutService.getLayoutValue('navigation');
   const showPanZoomButtons =
     navigation &&
     element.clientWidth >= NUMBERS.LAYOUT_MODES.MEDIUM_NAV.width &&


### PR DESCRIPTION
Fix for [QB-10212](https://jira.qlikdev.com/browse/QB-10212).

If `navigation` was missing in layout, `show` would be set to `undefined`, which is the same as not defining a show function at all, and then it defaults to `true`.