### PR TITLE
fix: remove constraints from useEffect of useSettings

### DIFF
--- a/src/hooks/__tests__/use-settings.spec.js
+++ b/src/hooks/__tests__/use-settings.spec.js
@@ -47,7 +47,6 @@ describe('use-settings', () => {
     chartModel = {
       query: {
         getDataHandler: sandbox.stub().returns(dataHandler),
-        getMeta: sandbox.stub().returns({ previousConstraints: undefined }),
       },
       command: { layoutComponents: sandbox.stub(), setMeta: sandbox.stub() },
     };
@@ -117,7 +116,7 @@ describe('use-settings', () => {
     });
   });
 
-  describe('useEffect 1', () => {
+  describe('useEffect', () => {
     it('should have the second argument being an array with correct elements', () => {
       create();
       conditionArray = stardust.useEffect.getCall(0).args[1];
@@ -142,58 +141,11 @@ describe('use-settings', () => {
         expect(result).to.equal(undefined);
       });
 
-      it('should call chartModel setMeta correctly, case 1: normal resize', () => {
+      it('should call chartModel setMeta correctly', () => {
         stardust.useConstraints.returns({});
-        chartModel.query.getMeta.returns({ previousConstraints: {} });
-        create();
-        fn = stardust.useEffect.getCall(2).args[0];
         fn();
-        expect(chartModel.command.setMeta.firstCall).to.have.been.calledWithExactly({ constraintsHaveChanged: false });
-        expect(chartModel.command.setMeta.secondCall).to.have.been.calledWithExactly({ previousConstraints: {} });
-      });
-
-      it('should call chartModel setMeta correctly, case 2: resize accompanied by constraints changed', () => {
-        stardust.useConstraints.returns({});
-        chartModel.query.getMeta.returns({ previousConstraints: { active: false } });
-        create();
-        fn = stardust.useEffect.getCall(2).args[0];
-        fn();
-        expect(chartModel.command.setMeta.firstCall).to.have.been.calledWithExactly({ constraintsHaveChanged: true });
-        expect(chartModel.command.setMeta.secondCall).to.have.been.calledWithExactly({
-          previousConstraints: {},
-        });
-      });
-
-      it('should call setSettings with the new settings ', () => {
-        fn();
-        expect(setSettings).to.have.been.calledWithExactly('new-settings');
-      });
-    });
-  });
-
-  describe('useEffect 2', () => {
-    it('should have the second argument being an array with correct elements', () => {
-      create();
-      conditionArray = stardust.useEffect.getCall(1).args[1];
-      expect(conditionArray).to.deep.equal([300]);
-    });
-
-    describe('the function in the arugment list', () => {
-      beforeEach(() => {
-        create();
-        fn = stardust.useEffect.getCall(1).args[0];
-      });
-
-      it('should resolve to nothing (undefined) when models are not defined', () => {
-        models = undefined;
-        const result = fn();
-        expect(result).to.equal(undefined);
-      });
-
-      it('should resolve to nothing (undefined) when colorService are not initialized', () => {
-        colorService.isInitialized.returns(false);
-        const result = fn();
-        expect(result).to.equal(undefined);
+        expect(chartModel.command.setMeta.firstCall).to.have.been.calledWithExactly({ sizeChanged: true });
+        expect(chartModel.command.setMeta.secondCall).to.have.been.calledWithExactly({ sizeChanged: undefined });
       });
 
       it('should call setSettings with the new settings ', () => {

--- a/src/hooks/use-settings.js
+++ b/src/hooks/use-settings.js
@@ -81,7 +81,7 @@ const useSettings = ({ core, models, flags }) => {
     chartModel.command.setMeta({ sizeChanged: undefined });
     updateViewState({ viewState, viewStateOptions: options.viewState, models });
     setSettings(newSettings);
-  }, [rect.width, rect.height, constraints]);
+  }, [rect.width, rect.height]);
 
   return settings;
 };

--- a/src/hooks/use-settings.js
+++ b/src/hooks/use-settings.js
@@ -64,7 +64,11 @@ const useSettings = ({ core, models, flags }) => {
     });
   }, [models]);
 
-  const update = () => {
+  useEffect(() => {
+    if (!models || !models?.colorService.isInitialized()) {
+      return;
+    }
+
     const { layoutService, chartModel, dockService, colorService } = models;
     const { viewState } = core;
     const logicalSize = getLogicalSize({ layout: layoutService.getLayout(), options });
@@ -72,35 +76,12 @@ const useSettings = ({ core, models, flags }) => {
     colorService.custom.updateLegend();
 
     const newSettings = getPicassoDef(logicalSize || rect);
+    chartModel.command.setMeta({ sizeChanged: true });
     chartModel.command.layoutComponents({ settings: newSettings });
+    chartModel.command.setMeta({ sizeChanged: undefined });
     updateViewState({ viewState, viewStateOptions: options.viewState, models });
     setSettings(newSettings);
-  };
-
-  useEffect(() => {
-    if (!models || !models?.colorService.isInitialized()) {
-      return;
-    }
-
-    const { chartModel } = models;
-    if (JSON.stringify(constraints) === JSON.stringify(chartModel.query.getMeta().previousConstraints)) {
-      chartModel.command.setMeta({ constraintsHaveChanged: false });
-    } else {
-      chartModel.command.setMeta({ constraintsHaveChanged: true });
-    }
-
-    chartModel.command.setMeta({ previousConstraints: { ...constraints } });
-
-    update();
-  }, [rect.width, rect.height]);
-
-  useEffect(() => {
-    if (!models || !models?.colorService.isInitialized()) {
-      return;
-    }
-
-    update();
-  }, [constraints]);
+  }, [rect.width, rect.height, constraints]);
 
   return settings;
 };

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -158,7 +158,7 @@ describe('chart-model', () => {
       it('should return correct meta', () => {
         expect(create().query.getMeta()).to.deep.equal({
           isPrelayout: true,
-          sizeChanged: false,
+          sizeChanged: undefined,
           updateWithSettings: undefined,
           progressive: false,
         });
@@ -181,7 +181,7 @@ describe('chart-model', () => {
 
         viewHandler.setInteractionInProgress(false);
         layoutService.meta.isBigData = true;
-        chartModel.command.setMeta({ updateWithSettings: true, sizeChanged: false });
+        chartModel.command.setMeta({ updateWithSettings: true, sizeChanged: undefined });
         expect(chartModel.query.animationEnabled()).to.equal(true);
 
         layoutService.meta.isBigData = false;

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -158,9 +158,8 @@ describe('chart-model', () => {
       it('should return correct meta', () => {
         expect(create().query.getMeta()).to.deep.equal({
           isPrelayout: true,
-          previousConstraints: undefined,
+          sizeChanged: false,
           updateWithSettings: undefined,
-          constraintsHaveChanged: undefined,
           progressive: false,
         });
       });
@@ -182,7 +181,7 @@ describe('chart-model', () => {
 
         viewHandler.setInteractionInProgress(false);
         layoutService.meta.isBigData = true;
-        chartModel.command.setMeta({ updateWithSettings: true, constraintsHaveChanged: false });
+        chartModel.command.setMeta({ updateWithSettings: true, sizeChanged: false });
         expect(chartModel.query.animationEnabled()).to.equal(true);
 
         layoutService.meta.isBigData = false;

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -102,7 +102,7 @@ export default function createChartModel({
   const meta = {
     isPrelayout: true,
     updateWithSettings: undefined,
-    sizeChanged: false,
+    sizeChanged: undefined,
     progressive: false,
   };
 

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -101,9 +101,8 @@ export default function createChartModel({
 
   const meta = {
     isPrelayout: true,
-    previousConstraints: undefined,
     updateWithSettings: undefined,
-    constraintsHaveChanged: undefined,
+    sizeChanged: false,
     progressive: false,
   };
 
@@ -275,7 +274,7 @@ export default function createChartModel({
 
   const animationEnabled = () => {
     const interactionInProgress = viewHandler.getInteractionInProgress();
-    if (interactionInProgress || !meta.updateWithSettings || meta.constraintsHaveChanged) {
+    if (interactionInProgress || !meta.updateWithSettings || meta.sizeChanged) {
       return false;
     }
 


### PR DESCRIPTION
As @tasseKATT pointed out, splitting size and constraints useEffect hooks (https://github.com/qlik-oss/sn-scatter-plot/pull/261) causes unnecessary renderings and problem with elongated points.
Since animations don't give users added value when resizing, animations can be disable as well when resizing.

What's more, Niclas and I realised that we don't need to monitor `constraints` in the `useEffect` hook of the useSettings, since when constraints change, we don't need to update `dockService`, `colorService` or `settings`.
I have tested going in and out of `Edit Sheet`, lasso selection, and tooltip in `Play Story` of Storytelling to verify that the constraints are still working properly after the fix.