### PR TITLE
refactor: use event.srcEvent instead of event.center to calculate tap position

### DIFF
--- a/src/custom-tooltip/utils.js
+++ b/src/custom-tooltip/utils.js
@@ -5,15 +5,9 @@ import tooltipChart from './chart/index';
 
 // used by the deprecated custom tooltip
 function toPoint(event, chart) {
-  let x = 0;
-  let y = 0;
-  if (event.center) {
-    x += event.center.x;
-    y += event.center.y;
-  } else {
-    x += event.clientX;
-    y += event.clientY;
-  }
+  const x = event.clientX === undefined ? Math.floor(event.srcEvent.clientX) : event.clientX;
+  const y = event.clientY === undefined ? Math.floor(event.srcEvent.clientY) : event.clientY;
+
   const chartBounds = chart.element.getBoundingClientRect();
   const cx = x - chartBounds.left;
   const cy = y - chartBounds.top;

--- a/src/interactive/tap/event.js
+++ b/src/interactive/tap/event.js
@@ -3,15 +3,8 @@ import { updateLazySelectionOnEnd } from '../update-selection';
 function eventToLocalPoint(event, chart) {
   const bounds = chart.element.getBoundingClientRect();
 
-  let x;
-  let y;
-  if (event.center) {
-    ({ x } = event.center);
-    ({ y } = event.center);
-  } else {
-    x = event.clientX;
-    y = event.clientY;
-  }
+  const x = event.clientX === undefined ? Math.floor(event.srcEvent.clientX) : event.clientX;
+  const y = event.clientY === undefined ? Math.floor(event.srcEvent.clientY) : event.clientY;
 
   return {
     x: x - bounds.left,


### PR DESCRIPTION
The x and y coordinates in `event.center` from HammerJS events are rounded up and can therefore differ from the x and y coordinates from the native mousemove `event` which is rounded down.

Changing to use `event.srcEvent` instead of event.center and rounding the value down when the event comes from HammerJS.

This is to get same results from `chart.shapesAt` look-ups based on coordinates from for example tap selections (HammerJS event) and tooltip hover (native mousemove event).