### PR TITLE
fix: axis tick value labels in auto format case (#350)

### DIFF
--- a/src/models/chart-model/__tests__/format-pattern-from-range.spec.js
+++ b/src/models/chart-model/__tests__/format-pattern-from-range.spec.js
@@ -1,19 +1,19 @@
 import * as KEYS from '../../../constants/keys';
-import getFormatPatternFromRange from '../format-pattern-from-range';
+import getAutoFormatPatternFromRange from '../format-pattern-from-range';
 
-describe('getFormatPatternFromRange', () => {
+describe('getAutoFormatPatternFromRange', () => {
   let sandbox;
   let create;
   let scaleName;
   let viewHandler;
-  let layoutService;
+  let localeInfo;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(KEYS, 'default').value({ SCALE: { X: 'x', Y: 'y' } });
     viewHandler = { getMeta: sandbox.stub() };
-    layoutService = { getHyperCubeValue: sandbox.stub() };
-    create = () => getFormatPatternFromRange(scaleName, viewHandler, layoutService);
+    localeInfo = {};
+    create = () => getAutoFormatPatternFromRange(scaleName, viewHandler, localeInfo);
   });
 
   afterEach(() => {
@@ -29,31 +29,31 @@ describe('getFormatPatternFromRange', () => {
   it('should correct format pattern when, case 1: xRange = [800M, 801M], thousand delimiter is undefined', () => {
     scaleName = 'x';
     viewHandler.getMeta.returns({ homeStateDataView: { xAxisMin: 800000000, xAxisMax: 801000000 } });
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qThou').returns(undefined);
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qDec').returns('d');
+    localeInfo.qThousandSep = undefined;
+    localeInfo.qDecimalSep = 'd';
     expect(create()).to.equal('0d####');
   });
 
   it('should correct format pattern when, case 2: xRange = [800M, 800M]', () => {
     scaleName = 'x';
     viewHandler.getMeta.returns({ homeStateDataView: { xAxisMin: 800000000, xAxisMax: 800000000 } });
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.0.qNumFormat.qDec').returns('.');
+    localeInfo.qDecimalSep = '.';
     expect(create()).to.equal('0.##');
   });
 
   it('should correct format pattern when, case 3: yRange = [0.001, 0.081]', () => {
     scaleName = 'y';
     viewHandler.getMeta.returns({ homeStateDataView: { yAxisMin: 0.001, yAxisMax: 0.081 } });
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qThou').returns(',');
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qDec').returns('.');
+    localeInfo.qThousandSep = ',';
+    localeInfo.qDecimalSep = '.';
     expect(create()).to.equal('#,##0.###');
   });
 
   it('should correct format pattern when, case 4: yRange = [0.01, 10.01]', () => {
     scaleName = 'y';
     viewHandler.getMeta.returns({ homeStateDataView: { yAxisMin: 0.01, yAxisMax: 10.01 } });
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qThou').returns(',');
-    layoutService.getHyperCubeValue.withArgs('qMeasureInfo.1.qNumFormat.qDec').returns('.');
+    localeInfo.qThousandSep = ',';
+    localeInfo.qDecimalSep = '.';
     expect(create()).to.equal('#,##0.#');
   });
 });

--- a/src/models/chart-model/__tests__/index.spec.js
+++ b/src/models/chart-model/__tests__/index.spec.js
@@ -1,6 +1,6 @@
 import * as KEYS from '../../../constants/keys';
 import createChartModel from '..';
-import * as getFormatPatternFromRange from '../format-pattern-from-range';
+import * as getAutoFormatPatternFromRange from '../format-pattern-from-range';
 import * as shouldUpdateTicks from '../should-update-ticks';
 import * as createViewHandler from '../../../view-handler';
 
@@ -82,7 +82,7 @@ describe('chart-model', () => {
     colorService = {
       getData: colorModelDataFn,
     };
-    sandbox.stub(getFormatPatternFromRange, 'default');
+    sandbox.stub(getAutoFormatPatternFromRange, 'default');
     sandbox.stub(shouldUpdateTicks, 'default').returns(false);
     create = () =>
       createChartModel({
@@ -113,7 +113,7 @@ describe('chart-model', () => {
         'getDataHandler',
         'getLocaleInfo',
         'getMeta',
-        'getFormatPattern',
+        'getAutoFormatPattern',
         'animationEnabled',
         'miniChartEnabled',
       ]);
@@ -154,10 +154,10 @@ describe('chart-model', () => {
       });
     });
 
-    describe('getFormatPattern', () => {
-      it('should call getFormatPatternFromRange', () => {
-        create().query.getFormatPattern('x');
-        expect(getFormatPatternFromRange.default).to.have.been.calledOnce;
+    describe('getAutoFormatPattern', () => {
+      it('should call getAutoFormatPatternFromRange', () => {
+        create().query.getAutoFormatPattern('x');
+        expect(getAutoFormatPatternFromRange.default).to.have.been.calledOnce;
       });
     });
 

--- a/src/models/chart-model/format-pattern-from-range.js
+++ b/src/models/chart-model/format-pattern-from-range.js
@@ -1,6 +1,10 @@
 import KEYS from '../../constants/keys';
 
-export default function getFormatPatternFromRange(scaleName, viewHandler, layoutService) {
+export default function getAutoFormatPatternFromRange(scaleName, viewHandler, localeInfo) {
+  if (!localeInfo) {
+    return '';
+  }
+
   let min;
   let max;
   if (scaleName === KEYS.SCALE.X) {
@@ -20,9 +24,9 @@ export default function getFormatPatternFromRange(scaleName, viewHandler, layout
 
   let nDecimals = Math.abs(rangeMagnitude);
 
-  const field = scaleName === KEYS.SCALE.X ? 'qMeasureInfo.0' : 'qMeasureInfo.1';
-  const thousandDelimiter = layoutService.getHyperCubeValue(`${field}.qNumFormat.qThou`, false);
-  const decimalDelimiter = layoutService.getHyperCubeValue(`${field}.qNumFormat.qDec`, '.');
+  const thousandDelimiter = localeInfo.qThousandSep || false;
+  const decimalDelimiter = localeInfo.qDecimalSep || '.';
+
   if (range === 0) {
     return '0'.concat(decimalDelimiter, '##');
   }

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -2,7 +2,7 @@ import extend from 'extend';
 import KEYS from '../../constants/keys';
 import NUMBERS from '../../constants/numbers';
 import createViewHandler from '../../view-handler';
-import getFormatPatternFromRange from './format-pattern-from-range';
+import getAutoFormatPatternFromRange from './format-pattern-from-range';
 import shouldUpdateTicks from './should-update-ticks';
 
 export default function createChartModel({
@@ -204,7 +204,7 @@ export default function createChartModel({
       getViewHandler: () => viewHandler,
       getDataHandler: () => dataHandler,
       getLocaleInfo: () => localeInfo,
-      getFormatPattern: (scaleName) => getFormatPatternFromRange(scaleName, viewHandler, layoutService),
+      getAutoFormatPattern: (scaleName) => getAutoFormatPatternFromRange(scaleName, viewHandler, localeInfo),
       getMeta: () => meta,
       animationEnabled,
       miniChartEnabled,

--- a/src/models/tick-model/__tests__/index.spec.js
+++ b/src/models/tick-model/__tests__/index.spec.js
@@ -24,7 +24,7 @@ describe('createTickModel', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    chartModel = { query: { getFormatPattern: sandbox.stub() } };
+    chartModel = { query: { getAutoFormatPattern: sandbox.stub() } };
     layoutService = { getLayoutValue: sandbox.stub(), getHyperCubeValue: sandbox.stub() };
     layoutService.getLayoutValue.withArgs('xAxis.spacing', 1).returns(0.5);
     layoutService.getLayoutValue.withArgs('yAxis.spacing', 1).returns(2);
@@ -84,7 +84,7 @@ describe('createTickModel', () => {
             formatter: sinon.match.object,
           })
           .returns({ ticks: 'correct ticks', minMax: 'correct minMax' });
-        chartModel.query.getFormatPattern.withArgs('x').returns('#.###');
+        chartModel.query.getAutoFormatPattern.withArgs('x').returns('#.###');
       });
 
       it('should return correct X ticks, when it is not autoFormat', () => {

--- a/src/models/tick-model/index.js
+++ b/src/models/tick-model/index.js
@@ -55,7 +55,7 @@ export default function createTickModel({
       const field = axis === KEYS.SCALE.X ? 'qMeasureInfo.0' : 'qMeasureInfo.1';
       const isAutoFormat = layoutService.getHyperCubeValue(`${field}.qIsAutoFormat`, false);
       if (isAutoFormat) {
-        formatPatterns[axis] = chartModel.query.getFormatPattern(axis);
+        formatPatterns[axis] = chartModel.query.getAutoFormatPattern(axis);
       }
     }
 


### PR DESCRIPTION
## Description:
Cherry pick from this PR by Quan: https://github.com/qlik-oss/sn-scatter-plot/pull/350
To patch this bug: https://jira.qlikdev.com/browse/QB-16713
File changes are identical to https://github.com/qlik-oss/sn-scatter-plot/pull/350, except for the png file, which did not exist in v3.19.3
## Verification:
![image](https://user-images.githubusercontent.com/70384379/199007867-3610c9e1-6618-4cb0-bf82-d1b92d17925f.png)
