### PR TITLE
feat: enabled new styling panel

### DIFF
--- a/src/ext/property-definition/index.js
+++ b/src/ext/property-definition/index.js
@@ -6,6 +6,7 @@ import colorModeOptions from './color-mode-options';
 import showUseDimValCol from '../show-use-dim-val-col';
 import compressionNoteProperties from './compression-note-properties';
 import NUMBERS from '../../constants/numbers';
+import getStylingPanelDefinition from './styling-panel-definition';
 
 const { MAX_NR_SCATTER, DEFAULT_VISIBLE_BUBBLES, MAX_VISIBLE_BUBBLES } = NUMBERS;
 
@@ -13,6 +14,10 @@ const persistentColorsShow = (data) => !getValue(data, 'color.auto') && getValue
 
 export default function propertyDefinition(env) {
   const { flags } = env;
+
+  // Feature Flags for Styling Panel
+  const stylingPanelEnabled = flags.isEnabled('SENSECLIENT_IM_2206_STYLINGPANEL_SCATTERPLOT');
+  const bkgOptionsEnabled = flags.isEnabled('SENSECLIENT_IM_2206_SCATTERPLOT_BG');
 
   const trendlines = trendlineDefinition(env);
 
@@ -185,6 +190,7 @@ export default function propertyDefinition(env) {
         translation: 'properties.presentation',
         grouped: true,
         items: {
+          styleEditor: stylingPanelEnabled && getStylingPanelDefinition(bkgOptionsEnabled),
           showNavigation: {
             ref: 'navigation',
             type: 'boolean',

--- a/src/ext/property-definition/styling-panel-definition.js
+++ b/src/ext/property-definition/styling-panel-definition.js
@@ -1,0 +1,11 @@
+const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
+  component: 'styling-panel',
+  chartTitle: 'Object.ScatterPlot',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  ref: 'components',
+  useGeneral: true,
+  useBackground: bkgOptionsEnabled,
+});
+
+export default getStylingPanelDefinition;


### PR DESCRIPTION
This PR enables the new styling panel (SENSECLIENT_IM_2206_STYLINGPANEL_SCATTERPLOT) with background options (SENSECLIENT_IM_323_BACKGROUND_OPTIONS) in scatter plot