### PR TITLE
fix(QB-17405): pick up and apply DQ limitations

### DIFF
--- a/src/hooks/use-models.js
+++ b/src/hooks/use-models.js
@@ -44,7 +44,7 @@ const useModels = ({ core, flags }) => {
   const rect = useRect();
   const selections = useSelections();
   const app = useApp();
-  const { qLocaleInfo: localeInfo, qIsDirectQueryMode, qUnsupportedFeature } = useAppLayout();
+  const { qLocaleInfo: localeInfo, qUnsupportedFeatures } = useAppLayout();
   const plugins = usePlugins();
   const [selectionService, setSelectionService] = useState();
   const [models, setModels] = useState();
@@ -83,7 +83,7 @@ const useModels = ({ core, flags }) => {
 
     const layoutService = createLayoutService({
       source: layout,
-      metaAdditionsFn: layoutServiceMeta(flags, qIsDirectQueryMode, qUnsupportedFeature),
+      metaAdditionsFn: layoutServiceMeta(flags, qUnsupportedFeatures),
     });
     const logicalSize = getLogicalSize({ layout: layoutService.getLayout(), options });
     const dockService = createDockService({
@@ -215,8 +215,7 @@ const useModels = ({ core, flags }) => {
     translator.language(),
     options.direction,
     options.viewState,
-    qIsDirectQueryMode,
-    qUnsupportedFeature,
+    qUnsupportedFeatures,
   ]);
 
   return models;

--- a/src/services/layout-service/__tests__/meta.spec.js
+++ b/src/services/layout-service/__tests__/meta.spec.js
@@ -8,13 +8,11 @@ describe('meta', () => {
   let create;
   let flags;
   let layout;
-  let qIsDirectQueryMode;
-  let qUnsupportedFeature;
+  let qUnsupportedFeatures;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    qIsDirectQueryMode = false;
-    qUnsupportedFeature = [];
+    qUnsupportedFeatures = [];
     layout = { snapshotData: 'some-data', qHyperCube: 'hpc' };
     sandbox.stub(chartModule, 'getValue');
     sandbox
@@ -23,36 +21,16 @@ describe('meta', () => {
     flags = { isEnabled: sandbox.stub() };
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(false);
     flags.isEnabled.withArgs('PROGRESSIVE_RENDERING').returns(false);
-    create = () => createMeta(flags, qIsDirectQueryMode, qUnsupportedFeature);
+    create = () => createMeta(flags, qUnsupportedFeatures);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should return correct meta object, when it is not BDI live mode', () => {
+  it('should return correct meta object', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
-    expect(create()({ layout })).to.deep.equal({
-      isSnapshot: true,
-      hasSizeMeasure: true,
-      isBigData: true,
-      isContinuous: true,
-      isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: false,
-      isProgressiveEnabled: false,
-      isLargeNumDataPoints: false,
-      maxVisibleBubbles: 100,
-      largeNumDataPoints: 100,
-      numDataPoints: 101,
-    });
-  });
-
-  it('should return correct meta object, when it is BDI live mode but BDI flag is not enabled', () => {
-    chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
-    chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     expect(create()({ layout })).to.deep.equal({
       isSnapshot: true,
       hasSizeMeasure: true,
@@ -69,41 +47,41 @@ describe('meta', () => {
   });
 
   it('should return correct meta object, when binning is not supported', () => {
-    qIsDirectQueryMode = true;
-    qUnsupportedFeature = ['binningData'];
+    qUnsupportedFeatures = ['binningData'];
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
-    chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
+    chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(15000);
     expect(create()({ layout })).to.deep.equal({
       isSnapshot: true,
       hasSizeMeasure: true,
       isBigData: false,
       isContinuous: true,
-      isRangeSelectionsSupported: false,
+      isRangeSelectionsSupported: true,
       isMaxVisibleBubblesEnabled: false,
       isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 100,
       largeNumDataPoints: 100,
-      numDataPoints: 101,
+      numDataPoints: 15000,
     });
   });
 
   it('should return correct meta object, when range selections is not supported', () => {
-    qIsDirectQueryMode = true;
-    qUnsupportedFeature = ['rangeSelections'];
+    qUnsupportedFeatures = ['rangeSelections'];
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
+    flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
+    layout.maxVisibleBubbles = 300;
     expect(create()({ layout })).to.deep.equal({
       isSnapshot: true,
       hasSizeMeasure: true,
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: false,
-      isMaxVisibleBubblesEnabled: false,
+      isMaxVisibleBubblesEnabled: true,
       isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
-      maxVisibleBubbles: 100,
-      largeNumDataPoints: 100,
+      maxVisibleBubbles: 300,
+      largeNumDataPoints: 300,
       numDataPoints: 101,
     });
   });
@@ -111,8 +89,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and qcy < maxVisibleBubbles < LARGE_NUM_DATA_POINTS', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 300;
     expect(create()({ layout })).to.deep.equal({
@@ -133,8 +109,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and maxVisibleBubbles < qcy < LARGE_NUM_DATA_POINTS', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(400);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 300;
     expect(create()({ layout })).to.deep.equal({
@@ -155,8 +129,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and maxVisibleBubbles < LARGE_NUM_DATA_POINTS < qcy', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(600);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 300;
     expect(create()({ layout })).to.deep.equal({
@@ -177,8 +149,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and qcy < LARGE_NUM_DATA_POINTS < maxVisibleBubbles', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(101);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 600;
     expect(create()({ layout })).to.deep.equal({
@@ -199,8 +169,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and LARGE_NUM_DATA_POINTS < qcy < maxVisibleBubbles', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(550);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 600;
     expect(create()({ layout })).to.deep.equal({
@@ -221,8 +189,6 @@ describe('meta', () => {
   it('should return correct meta object, when NUM_BUBBLES flag is enabled and LARGE_NUM_DATA_POINTS < maxVisibleBubbles < qcy', () => {
     chartModule.getValue.withArgs('hpc', 'qMeasureInfo.2').returns('some-info');
     chartModule.getValue.withArgs('hpc', 'qSize.qcy').returns(800);
-    layout.qIsBDILiveMode = true;
-    flags.isEnabled.withArgs('BDI_CLIENT_ADAPT').returns(false);
     flags.isEnabled.withArgs('NUM_BUBBLES').returns(true);
     layout.maxVisibleBubbles = 600;
     expect(create()({ layout })).to.deep.equal({

--- a/src/services/layout-service/meta.js
+++ b/src/services/layout-service/meta.js
@@ -1,22 +1,20 @@
 import { getValue } from 'qlik-chart-modules';
 import NUMBERS from '../../constants/numbers';
 
-export default function createLayoutServiceMetaFn(flags, qIsDirectQueryMode, qUnsupportedFeature) {
+export default function createLayoutServiceMetaFn(flags, qUnsupportedFeatures) {
   return function layoutServiceMeta({ layout }) {
     const isSnapshot = !!layout.snapshotData;
     const hasSizeMeasure = !!getValue(layout.qHyperCube, 'qMeasureInfo.2');
     const qcy = getValue(layout.qHyperCube, 'qSize.qcy');
-    const isBinningSupported = !qIsDirectQueryMode && !qUnsupportedFeature?.some((f) => f === 'binningData');
+    const isBinningSupported = !qUnsupportedFeatures?.some((f) => f === 'binningData');
     const isMaxVisibleBubblesEnabled = flags.isEnabled('NUM_BUBBLES');
     const isProgressiveEnabled = flags.isEnabled('PROGRESSIVE_RENDERING');
     const maxVisibleBubbles =
       !isMaxVisibleBubblesEnabled || layout.maxVisibleBubbles === undefined || layout.maxVisibleBubbles <= 0
         ? NUMBERS.MAX_NR_SCATTER
         : Math.min(NUMBERS.MAX_VISIBLE_BUBBLES, Math.max(NUMBERS.MAX_NR_SCATTER, Math.ceil(layout.maxVisibleBubbles)));
-    const isBigData =
-      isBinningSupported && qcy > maxVisibleBubbles && !(layout?.qIsBDILiveMode && flags.isEnabled('BDI_CLIENT_ADAPT'));
-    const isRangeSelectionsSupported =
-      !qIsDirectQueryMode && !qUnsupportedFeature?.some((f) => f === 'rangeSelections');
+    const isBigData = isBinningSupported && qcy > maxVisibleBubbles;
+    const isRangeSelectionsSupported = !qUnsupportedFeatures?.some((f) => f === 'rangeSelections');
     const largeNumDataPoints = Math.min(NUMBERS.LARGE_NUM_DATA_POINTS, maxVisibleBubbles);
     const isLargeNumDataPoints = !isBigData && isMaxVisibleBubblesEnabled && qcy > largeNumDataPoints;
 


### PR DESCRIPTION
Corrects property name `qUnsupportedFeatures` and updates the use of it slightly. Gets rid of some BDI checks as well, which are not relevant any longer.