### PR TITLE
fix: disable animations when properties change

### DIFF
--- a/src/constants/paths.js
+++ b/src/constants/paths.js
@@ -1,0 +1,19 @@
+export default {
+  dataRelatedPropertiesPaths: [
+    'qHyperCube.qDataPages',
+    'qHyperCube.qGrandTotalRow',
+    'qHyperCube.qHasOtherValues',
+    'qHyperCube.qSize',
+    'qHyperCube.qStackedDataPages',
+    'qHyperCube.qDimensionInfo[].qAttrDimInfo',
+    'qHyperCube.qDimensionInfo[].qCardinalities',
+    'qHyperCube.qDimensionInfo[].qMax',
+    'qHyperCube.qDimensionInfo[].qMin',
+    'qHyperCube.qDimensionInfo[].qStateCounts',
+    'qHyperCube.qMeasureInfo[].qApprMaxGlyphCount',
+    'qHyperCube.qMeasureInfo[].qMax',
+    'qHyperCube.qMeasureInfo[].qMin',
+    'qHyperCube.qTreeDataPages',
+    'qHyperCube.qTreeNodesOnDim',
+  ],
+};

--- a/src/constants/paths.js
+++ b/src/constants/paths.js
@@ -1,10 +1,8 @@
 export default {
   dataRelatedPropertiesPaths: [
-    'qHyperCube.qDataPages',
     'qHyperCube.qGrandTotalRow',
     'qHyperCube.qHasOtherValues',
     'qHyperCube.qSize',
-    'qHyperCube.qStackedDataPages',
     'qHyperCube.qDimensionInfo[].qAttrDimInfo',
     'qHyperCube.qDimensionInfo[].qCardinalities',
     'qHyperCube.qDimensionInfo[].qMax',
@@ -13,7 +11,6 @@ export default {
     'qHyperCube.qMeasureInfo[].qApprMaxGlyphCount',
     'qHyperCube.qMeasureInfo[].qMax',
     'qHyperCube.qMeasureInfo[].qMin',
-    'qHyperCube.qTreeDataPages',
     'qHyperCube.qTreeNodesOnDim',
   ],
 };

--- a/src/models/chart-model/__tests__/animations-properties-handler.spec.js
+++ b/src/models/chart-model/__tests__/animations-properties-handler.spec.js
@@ -1,0 +1,74 @@
+import * as PATHS from '../../../constants/paths';
+import { cacheProperties, propertiesHaveChanged } from '../animations-properties-handler';
+
+describe('black-list-properties-handler', () => {
+  let viewCache;
+  let cachedContent;
+  let layout;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    cachedContent = {};
+    viewCache = {
+      set: (prop, value) => {
+        cachedContent[prop] = value;
+      },
+      get: (prop) => cachedContent[prop],
+    };
+    sandbox.stub(PATHS, 'default').get(() => ({
+      dataRelatedPropertiesPaths: ['dog.speed', 'cat.legs[].color'],
+    }));
+    layout = {
+      dog: { speed: 'fast', ears: [{ shape: 'bat' }, { shape: 'drop' }] },
+      cat: { fur: 'black', legs: [{ color: 'red' }, { color: 'pink' }, { color: 'blue' }, { color: 'tan' }] },
+    };
+    cacheProperties({ viewCache, layout });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('cacheProperties', () => {
+    it('should ignore data-related properties by setting them to null', () => {
+      expect(cachedContent).to.deep.equal({
+        dataIndependentProperties:
+          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]}}',
+      });
+    });
+
+    it('should take no action when path leads to unexisting property', () => {
+      sandbox.stub(PATHS, 'default').get(() => ({
+        dataRelatedPropertiesPaths: ['dog.speed', 'dog.tail', 'dog.eyes[].color', 'cat.legs[].color'],
+      }));
+      cacheProperties({ viewCache, layout });
+      expect(cachedContent).to.deep.equal({
+        dataIndependentProperties:
+          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]}}',
+      });
+    });
+  });
+
+  describe('propertiesHaveChanged', () => {
+    it('should return false if properties have not changed', () => {
+      expect(propertiesHaveChanged({ viewCache, layout })).to.equal(false);
+    });
+
+    it('should return true if properties that are not related to data, have changed', () => {
+      layout = {
+        dog: { speed: 'fast', ears: [{ shape: 'rose' }, { shape: 'drop' }] },
+        cat: { fur: 'white', legs: [{ color: 'red' }, { color: 'pink' }, { color: 'blue' }, { color: 'tan' }] },
+      };
+      expect(propertiesHaveChanged({ viewCache, layout })).to.equal(true);
+    });
+
+    it('should return false if properties that are related to data, have changed', () => {
+      layout = {
+        dog: { speed: 'slow', ears: [{ shape: 'bat' }, { shape: 'drop' }] },
+        cat: { fur: 'black', legs: [{ color: 'red' }, { color: 'gray' }, { color: 'blue' }, { color: 'tan' }] },
+      };
+      expect(propertiesHaveChanged({ viewCache, layout })).to.equal(false);
+    });
+  });
+});

--- a/src/models/chart-model/__tests__/animations-properties-handler.spec.js
+++ b/src/models/chart-model/__tests__/animations-properties-handler.spec.js
@@ -1,7 +1,7 @@
 import * as PATHS from '../../../constants/paths';
 import { cacheProperties, propertiesHaveChanged } from '../animations-properties-handler';
 
-describe('black-list-properties-handler', () => {
+describe('animations-properties-handler', () => {
   let viewCache;
   let cachedContent;
   let layout;
@@ -22,6 +22,7 @@ describe('black-list-properties-handler', () => {
     layout = {
       dog: { speed: 'fast', ears: [{ shape: 'bat' }, { shape: 'drop' }] },
       cat: { fur: 'black', legs: [{ color: 'red' }, { color: 'pink' }, { color: 'blue' }, { color: 'tan' }] },
+      qHyperCube: { qDataPages: 'pages', qStackedDataPages: 'stack' },
     };
     cacheProperties({ viewCache, layout });
   });
@@ -34,7 +35,7 @@ describe('black-list-properties-handler', () => {
     it('should ignore data-related properties by setting them to null', () => {
       expect(cachedContent).to.deep.equal({
         dataIndependentProperties:
-          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]}}',
+          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]},"qHyperCube":{"qDataPages":null,"qStackedDataPages":null,"qTreeDataPages":null}}',
       });
     });
 
@@ -45,7 +46,7 @@ describe('black-list-properties-handler', () => {
       cacheProperties({ viewCache, layout });
       expect(cachedContent).to.deep.equal({
         dataIndependentProperties:
-          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]}}',
+          '{"dog":{"speed":null,"ears":[{"shape":"bat"},{"shape":"drop"}]},"cat":{"fur":"black","legs":[{"color":null},{"color":null},{"color":null},{"color":null}]},"qHyperCube":{"qDataPages":null,"qStackedDataPages":null,"qTreeDataPages":null}}',
       });
     });
   });
@@ -59,6 +60,7 @@ describe('black-list-properties-handler', () => {
       layout = {
         dog: { speed: 'fast', ears: [{ shape: 'rose' }, { shape: 'drop' }] },
         cat: { fur: 'white', legs: [{ color: 'red' }, { color: 'pink' }, { color: 'blue' }, { color: 'tan' }] },
+        qHyperCube: { qDataPages: 'pages', qStackedDataPages: 'stack' },
       };
       expect(propertiesHaveChanged({ viewCache, layout })).to.equal(true);
     });
@@ -67,6 +69,7 @@ describe('black-list-properties-handler', () => {
       layout = {
         dog: { speed: 'slow', ears: [{ shape: 'bat' }, { shape: 'drop' }] },
         cat: { fur: 'black', legs: [{ color: 'red' }, { color: 'gray' }, { color: 'blue' }, { color: 'tan' }] },
+        qHyperCube: { qDataPages: 'pages', qStackedDataPages: 'stack' },
       };
       expect(propertiesHaveChanged({ viewCache, layout })).to.equal(false);
     });

--- a/src/models/chart-model/animations-properties-handler.js
+++ b/src/models/chart-model/animations-properties-handler.js
@@ -1,0 +1,38 @@
+import extend from 'extend';
+import { setValue, getValue } from 'qlik-chart-modules';
+import PATHS from '../../constants/paths';
+
+export function extractProperties(layout) {
+  const properties = extend(true, {}, layout);
+  const { dataRelatedPropertiesPaths: ignoredPaths } = PATHS;
+
+  ignoredPaths.forEach((path) => {
+    const subPaths = path.split('[');
+    if (subPaths.length === 1) {
+      if (getValue(properties, path) !== undefined) {
+        setValue(properties, path, null);
+      }
+    } else {
+      const arrayPath = subPaths[0];
+      const propPath = subPaths[1].split('].')[1];
+      const array = getValue(properties, arrayPath, []);
+      array.forEach((element) => {
+        if (getValue(element, propPath) !== undefined) {
+          setValue(element, propPath, null);
+        }
+      });
+    }
+  });
+
+  return properties;
+}
+
+export function cacheProperties({ viewCache, layout }) {
+  const properties = extractProperties(layout);
+  viewCache.set('dataIndependentProperties', JSON.stringify(properties));
+}
+
+export function propertiesHaveChanged({ viewCache, layout }) {
+  const properties = extractProperties(layout);
+  return viewCache.get('dataIndependentProperties') !== JSON.stringify(properties);
+}

--- a/src/models/chart-model/animations-properties-handler.js
+++ b/src/models/chart-model/animations-properties-handler.js
@@ -3,7 +3,15 @@ import { setValue, getValue } from 'qlik-chart-modules';
 import PATHS from '../../constants/paths';
 
 export function extractProperties(layout) {
-  const properties = extend(true, {}, layout);
+  // Destructuring to improve performance when data are large
+  const { qHyperCube, ...restOfLayout } = layout;
+  const { qDataPages, qStackedDataPages, qTreeDataPages, ...restOfCube } = qHyperCube;
+  const properties = extend(
+    true,
+    {},
+    { ...restOfLayout, qHyperCube: { ...restOfCube, qDataPages: null, qStackedDataPages: null, qTreeDataPages: null } }
+  );
+
   const { dataRelatedPropertiesPaths: ignoredPaths } = PATHS;
 
   ignoredPaths.forEach((path) => {

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -314,13 +314,13 @@ export default function createChartModel({
     const numOfPoints = layoutService.getHyperCubeValue('qSize.qcy', 0);
     if (
       options.chartAnimations === false ||
-      propertiesHaveChanged({ viewCache, layout: layoutService.getLayout() }) ||
       interactionInProgress ||
       meta.isPartialUpdating ||
       meta.isSizeChanging ||
       largeDataService.shouldUseProgressive() ||
       layoutService.meta.isBigData !== viewCache.get('isBigData') ||
-      (!layoutService.meta.isBigData && numOfPoints > NUMBERS.MAX_NR_ANIMATION)
+      (!layoutService.meta.isBigData && numOfPoints > NUMBERS.MAX_NR_ANIMATION) ||
+      propertiesHaveChanged({ viewCache, layout: layoutService.getLayout() })
     ) {
       return false;
     }

--- a/src/models/chart-model/index.js
+++ b/src/models/chart-model/index.js
@@ -7,6 +7,7 @@ import getAutoFormatPatternFromRange from './format-pattern-from-range';
 import shouldUpdateTicks from './should-update-ticks';
 import getVisiblePoints from '../../utils/get-visible-points';
 import areSameVisiblePoints from '../../utils/are-same-visible-points';
+import { cacheProperties, propertiesHaveChanged } from './animations-properties-handler';
 
 export default function createChartModel({
   chart,
@@ -24,7 +25,6 @@ export default function createChartModel({
   getCurrentYTicks,
   getYTicks,
   options,
-  constraints,
 }) {
   const EXCLUDE = [
     KEYS.COMPONENT.X_AXIS_TITLE,
@@ -243,6 +243,7 @@ export default function createChartModel({
       });
       updateMeta();
       viewCache.set('isBigData', layoutService.meta.isBigData);
+      cacheProperties({ viewCache, layout: layoutService.getLayout() });
       return Promise.resolve();
     }
     // Render the first time without data
@@ -252,6 +253,8 @@ export default function createChartModel({
       settings,
     });
     insertDataPages();
+    viewCache.set('isBigData', layoutService.meta.isBigData);
+    cacheProperties({ viewCache, layout: layoutService.getLayout() });
     return new Promise((resolve, reject) => renderProgressive(resolve, reject));
   };
 
@@ -308,23 +311,21 @@ export default function createChartModel({
 
   const animationsEnabled = () => {
     const interactionInProgress = viewHandler.getInteractionInProgress();
+    const numOfPoints = layoutService.getHyperCubeValue('qSize.qcy', 0);
     if (
       options.chartAnimations === false ||
-      constraints.active ||
+      propertiesHaveChanged({ viewCache, layout: layoutService.getLayout() }) ||
       interactionInProgress ||
       meta.isPartialUpdating ||
       meta.isSizeChanging ||
       largeDataService.shouldUseProgressive() ||
-      layoutService.meta.isBigData !== viewCache.get('isBigData')
+      layoutService.meta.isBigData !== viewCache.get('isBigData') ||
+      (!layoutService.meta.isBigData && numOfPoints > NUMBERS.MAX_NR_ANIMATION)
     ) {
       return false;
     }
 
-    if (layoutService.meta.isBigData) {
-      return true;
-    }
-
-    return layoutService.getHyperCubeValue('qSize.qcy', 0) <= NUMBERS.MAX_NR_ANIMATION && !interactionInProgress;
+    return true;
   };
 
   let updateTicks = false;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/qlik-trial/la-vie/blob/master/.github/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

## Description

Animations should only happen when data change, i.e. when users interact with components inside the chart.
Animations should be skipped when users change properties in Advanced Edit Mode, Simple Edit Mode, or Exploration Menu (soft properties).

Before this PR, to skip animations when properties change:
- For Advanced Edit Mode, `constraints.active` was used. This is not ideal, since `constraints.active` being true does not necessarily mean the sheet is in Advanced Edit Mode.
- For Simple Edit Mode and Exploration Menu, individual properties' values were cached and compared with the current values to see if they have changed. This is very tedious.

This PR proposes a better way ([src/models/chart-model/animations-properties-handler.js](https://github.com/qlik-oss/sn-scatter-plot/pull/377/files#diff-51ce3acb0256f9b41b29a71e78c0d91b172d273176834b40cd75060812dd90a8)):
- Cache properties: save current properties into viewCache, but only for properties that are not related to of data
- Check if properties have change: compare the current properties with the cached properties, again, only for those that are independent of data
- Caching properties is performed after the chart have been updated, and checking the changes is done in the animationsEnabled function of the chart.

<!-- Describe your changes below in as much detail as possible -->

## Verification

### Line chart

- Verify that animations work when interacting with chart, as before.
  - Normal case

     https://user-images.githubusercontent.com/70384379/223375255-d282ca34-f8f4-435e-b69a-ffcdb12ada59.mov

  - Large number of bubbles and progressive rendering is ON: animations should run when the number of points is below 1000 but not above.

     https://user-images.githubusercontent.com/70384379/223376560-a067de52-c68f-4f69-a163-e7065db1c170.mov

- Verify that there is no animation when changing properties in Advanced/Simple Edit and Exploration Menu.

   https://user-images.githubusercontent.com/70384379/223377074-3dbc8aa8-165c-4318-8f5f-ebfff14a980e.mov











