### PR TITLE
fix: animations of trendlines

### DIFF
--- a/src/services/trendlines-service/__tests__/index.spec.js
+++ b/src/services/trendlines-service/__tests__/index.spec.js
@@ -50,5 +50,45 @@ describe('trendlines-service', () => {
         compensateForLayoutChanges: sinon.match.func,
       },
     });
+
+    // animations.compensateForLayoutChanges
+    const currentNodes = [
+      {
+        major: { size: 1000, p: 'x' },
+        minor: { size: 500, p: 'y' },
+        points: [
+          { major: 0.25, minor: 0.75, minor0: 1 },
+          { major: 0.75, minor: 0.25, minor0: 1 },
+        ],
+      },
+    ];
+
+    const previousRect = { width: 1000, height: 500, x: 80, y: 50 };
+    const currentRect = { width: 1040, height: 470, x: 40, y: 80 };
+    const { compensateForLayoutChanges } = chartModules.trendlinesService.getCall(0).args[0].animations;
+    compensateForLayoutChanges({ currentNodes, currentRect, previousRect });
+    expect(currentNodes).to.deep.equal([
+      {
+        major: { size: 1000, p: 'x' },
+        minor: { size: 500, p: 'y' },
+        points: [
+          { major: 40 / 1000 + 0.25, minor: -30 / 500 + 0.75, minor0: -30 / 500 + 1, modified: true },
+          { major: 40 / 1000 + 0.75, minor: -30 / 500 + 0.25, minor0: -30 / 500 + 1, modified: true },
+        ],
+      },
+    ]);
+
+    // not compensate for nodes that have already modified
+    compensateForLayoutChanges({ currentNodes, currentRect, previousRect });
+    expect(currentNodes).to.deep.equal([
+      {
+        major: { size: 1000, p: 'x' },
+        minor: { size: 500, p: 'y' },
+        points: [
+          { major: 40 / 1000 + 0.25, minor: -30 / 500 + 0.75, minor0: -30 / 500 + 1, modified: true },
+          { major: 40 / 1000 + 0.75, minor: -30 / 500 + 0.25, minor0: -30 / 500 + 1, modified: true },
+        ],
+      },
+    ]);
   });
 });

--- a/src/services/trendlines-service/index.js
+++ b/src/services/trendlines-service/index.js
@@ -1,16 +1,6 @@
+/* eslint-disable no-param-reassign */
 import { trendlinesService } from 'qlik-chart-modules';
 import KEYS from '../../constants/keys';
-
-function movePath(path, distance) {
-  let counter = 0;
-  return path.replace(/[\d.e+-]+/g, (val) => {
-    ++counter;
-    if (counter % 2 === 1) {
-      return String(parseFloat(val) + distance);
-    }
-    return val;
-  });
-}
 
 export default function createTrenslinesService({
   chart,
@@ -47,11 +37,19 @@ export default function createTrenslinesService({
       compensateForLayoutChanges({ currentNodes, currentRect, previousRect }) {
         if (currentRect.x !== previousRect.x) {
           const deltaX = currentRect.x - previousRect.x;
+          const deltaY = currentRect.y - previousRect.y;
           currentNodes.forEach((node) => {
-            if (node.d) {
-              // eslint-disable-next-line no-param-reassign
-              node.d = movePath(node.d, -deltaX);
-            }
+            const deltaMajor = node.major.p === 'x' ? deltaX / node.major.size : deltaY / node.major.size;
+            const deltaMinor = node.minor.p === 'y' ? deltaY / node.minor.size : deltaX / node.minor.size;
+
+            node.points.forEach((point) => {
+              if (!point.modified) {
+                point.major -= deltaMajor;
+                point.minor -= deltaMinor;
+                point.minor0 -= deltaMinor;
+                point.modified = true;
+              }
+            });
           });
         }
       },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/qlik-trial/la-vie/blob/master/.github/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

## Description

<!-- Describe your changes below in as much detail as possible -->
Make animations work when there are trendlines.
In more details, this PR makes the trendlines animations compensation code work with current changes in Picasso about how to render line: https://github.com/qlik-oss/picasso.js/pull/766

## Verification

   https://user-images.githubusercontent.com/70384379/223431734-19f8e162-cf9f-46f8-bdc9-21ed29347a53.mov




