### PR TITLE
fix: add qTrendLines to data path

### DIFF
--- a/src/constants/paths.js
+++ b/src/constants/paths.js
@@ -11,6 +11,7 @@ export default {
     'qHyperCube.qMeasureInfo[].qApprMaxGlyphCount',
     'qHyperCube.qMeasureInfo[].qMax',
     'qHyperCube.qMeasureInfo[].qMin',
+    'qHyperCube.qMeasureInfo[].qTrendLines',
     'qHyperCube.qTreeNodesOnDim',
   ],
 };


### PR DESCRIPTION
## Description

Fix PR https://github.com/qlik-oss/sn-scatter-plot/pull/378
For some reason, I did not push the change in the path of trendlines to https://github.com/qlik-oss/sn-scatter-plot/pull/378

## Verification

Similar to videos in https://github.com/qlik-oss/sn-scatter-plot/pull/378