### PR TITLE
refactor: remove reference line label styling

### DIFF
--- a/src/ext/property-definition/styling-definitions/styling-panel-definition.js
+++ b/src/ext/property-definition/styling-definitions/styling-panel-definition.js
@@ -62,20 +62,6 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) 
             },
           }
         : undefined,
-      referenceLineLabel: flags?.isEnabled('CLIENT_IM_3050')
-        ? {
-            translation: 'properties.referenceLine.label.value',
-            component: 'panel-section',
-            items: {
-              labelItems: {
-                component: 'items',
-                ref: 'components',
-                key: 'referenceLine',
-                items: scatterPlotLabelsDefinition('referenceLine.label.name', fontResolver, theme),
-              },
-            },
-          }
-        : undefined,
     },
   };
 };

--- a/src/models/style-model/__tests__/index.spec.js
+++ b/src/models/style-model/__tests__/index.spec.js
@@ -179,20 +179,6 @@ describe('createStyleModel', () => {
           expect(fontFamily).to.equal(themeStyles.referenceLine.label.name.fontFamily);
           expect(fill).to.equal(themeStyles.referenceLine.label.name.color);
         });
-
-        it('should return reference line label component', () => {
-          component = {
-            key: 'referenceLine',
-            referenceLine: {
-              label: { name: { fontFamily: 'Arial, sans-serif', fontSize: '44', color: { color: 'yellow' } } },
-            },
-          };
-          layoutService.getLayoutValue.withArgs('components', []).returns([component, { key: 'line' }]);
-          const { fontSize, fontFamily, fill } = create().query.referenceLine.label.getStyle();
-          expect(fontSize).to.equal('44');
-          expect(fontFamily).to.equal('Arial, sans-serif');
-          expect(fill).to.equal('yellow');
-        });
       });
     });
   });

--- a/src/models/style-model/index.js
+++ b/src/models/style-model/index.js
@@ -10,15 +10,9 @@ export default function createStyleModel({ layoutService, themeService, flags })
     referenceLine: {
       label: {
         getStyle: () => ({
-          fill:
-            overrides('referenceLine')?.referenceLine?.label?.name?.color?.color ??
-            styles.referenceLine.label.name.color,
-          fontSize:
-            overrides('referenceLine')?.referenceLine?.label?.name?.fontSize ??
-            styles.referenceLine.label.name.fontSize,
-          fontFamily:
-            overrides('referenceLine')?.referenceLine?.label?.name?.fontFamily ??
-            styles.referenceLine.label.name.fontFamily,
+          fill: styles.referenceLine.label.name.color,
+          fontSize: styles.referenceLine.label.name.fontSize,
+          fontFamily: styles.referenceLine.label.name.fontFamily,
         }),
       },
     },


### PR DESCRIPTION
Reference line label styling will be part of a different JIRA ticket so I will remove it for now.