### PR TITLE
fix: remove empty styling chart tab when flag is off

### DIFF
--- a/src/ext/property-definition/styling-definitions/styling-panel-definition.js
+++ b/src/ext/property-definition/styling-definitions/styling-panel-definition.js
@@ -19,9 +19,9 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) 
     ref: 'components',
     useGeneral: true,
     useBackground: bkgOptionsEnabled,
-    items: {
-      axisTitleSection: flags?.isEnabled('CLIENT_IM_3050')
-        ? {
+    items: flags?.isEnabled('CLIENT_IM_3050')
+      ? {
+          axisTitleSection: {
             translation: 'properties.axis.title',
             component: 'panel-section',
             items: {
@@ -32,10 +32,8 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) 
                 items: scatterPlotLabelsDefinition('axis.title', fontResolver, theme),
               },
             },
-          }
-        : undefined,
-      axisLabelSection: flags?.isEnabled('CLIENT_IM_3050')
-        ? {
+          },
+          axisLabelSection: {
             translation: 'properties.axis.label',
             component: 'panel-section',
             items: {
@@ -46,10 +44,8 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) 
                 items: scatterPlotLabelsDefinition('axis.label.name', fontResolver, theme),
               },
             },
-          }
-        : undefined,
-      labelValueSection: flags?.isEnabled('CLIENT_IM_3050')
-        ? {
+          },
+          labelValueSection: {
             translation: 'properties.value.label',
             component: 'panel-section',
             items: {
@@ -60,9 +56,9 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) 
                 items: scatterPlotLabelsDefinition('label.value', fontResolver, theme),
               },
             },
-          }
-        : undefined,
-    },
+          },
+        }
+      : undefined,
   };
 };
 


### PR DESCRIPTION
Fixed a bug that resulted in an empty chart tab in the styling panel when flag CLIENT_IM_3050 was turned off.

Verification:
<img width="419" alt="Screenshot 2023-03-27 at 13 07 57" src="https://user-images.githubusercontent.com/8970708/227925091-624a4876-38fa-4a95-99b8-2775c3ed2a7d.png">
