### PR TITLE
chore: downgrade node version required

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sn-scatter-plot-ext"
   ],
   "engines": {
-    "node": ">=v18.16.0"
+    "node": ">=v18.15.0"
   },
   "main": "dist/sn-scatter-plot.js",
   "systemjs": "dist/sn-scatter-plot.systemjs.js",

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "semanticCommits": true,
   "rangeStrategy": "bump",
   "dependencyDashboard": true,
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "depTypeList": ["engines"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
For use in sense-client that only has node 18.15.0 because of https://github.com/nodejs/node/issues/47563