### PR TITLE
feat: add legend styling to scatter plot

### DIFF
--- a/src/ext/property-definition/styling-definitions/styling-panel-definition.js
+++ b/src/ext/property-definition/styling-definitions/styling-panel-definition.js
@@ -1,65 +1,102 @@
 import { fontResolver as createFontResolver } from 'qlik-chart-modules';
 import scatterPlotLabelsDefinition from './styling-utils';
 
-const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) => {
+const getStylingItems = (flags, translator, theme) => {
+  const items = {};
   const fontResolver = createFontResolver({
     theme,
     translator,
     config: {
       id: 'scatterPlot',
-      paths: ['axis.title', 'axis.label.name', 'label.value', 'referenceLine.label.name'],
+      paths: [
+        'axis.title',
+        'axis.label.name',
+        'label.value',
+        'referenceLine.label.name',
+        'legend.label',
+        'legend.title',
+      ],
     },
   });
 
-  return {
-    component: 'styling-panel',
-    chartTitle: 'Object.ScatterPlot',
-    translation: 'LayerStyleEditor.component.styling',
-    subtitle: 'LayerStyleEditor.component.styling',
-    ref: 'components',
-    useGeneral: true,
-    useBackground: bkgOptionsEnabled,
-    items: flags?.isEnabled('CLIENT_IM_3050')
-      ? {
-          axisTitleSection: {
-            translation: 'properties.axis.title',
-            component: 'panel-section',
-            items: {
-              labelItems: {
-                component: 'items',
-                ref: 'components',
-                key: 'axis',
-                items: scatterPlotLabelsDefinition('axis.title', fontResolver, theme),
-              },
-            },
-          },
-          axisLabelSection: {
-            translation: 'properties.axis.label',
-            component: 'panel-section',
-            items: {
-              labelItems: {
-                component: 'items',
-                ref: 'components',
-                key: 'axis',
-                items: scatterPlotLabelsDefinition('axis.label.name', fontResolver, theme),
-              },
-            },
-          },
-          labelValueSection: {
-            translation: 'properties.value.label',
-            component: 'panel-section',
-            items: {
-              labelItems: {
-                component: 'items',
-                ref: 'components',
-                key: 'label',
-                items: scatterPlotLabelsDefinition('label.value', fontResolver, theme),
-              },
-            },
-          },
-        }
-      : undefined,
-  };
+  if (flags?.isEnabled('CLIENT_IM_3050')) {
+    items.axisTitleSection = {
+      translation: 'properties.axis.title',
+      component: 'panel-section',
+      items: {
+        labelItems: {
+          component: 'items',
+          ref: 'components',
+          key: 'axis',
+          items: scatterPlotLabelsDefinition('axis.title', fontResolver, theme),
+        },
+      },
+    };
+    items.axisLabelSection = {
+      translation: 'properties.axis.label',
+      component: 'panel-section',
+      items: {
+        labelItems: {
+          component: 'items',
+          ref: 'components',
+          key: 'axis',
+          items: scatterPlotLabelsDefinition('axis.label.name', fontResolver, theme),
+        },
+      },
+    };
+    items.labelValueSection = {
+      translation: 'properties.value.label',
+      component: 'panel-section',
+      items: {
+        labelItems: {
+          component: 'items',
+          ref: 'components',
+          key: 'label',
+          items: scatterPlotLabelsDefinition('label.value', fontResolver, theme),
+        },
+      },
+    };
+  }
+
+  if (flags.isEnabled('CLIENT_IM_3051')) {
+    items.legendTitleSection = {
+      translation: 'properties.legend.title',
+      component: 'panel-section',
+      items: {
+        labelItems: {
+          component: 'items',
+          ref: 'components',
+          key: 'legend',
+          items: scatterPlotLabelsDefinition('legend.title', fontResolver, theme),
+        },
+      },
+    };
+    items.legendLabelSection = {
+      translation: 'properties.legend.label',
+      component: 'panel-section',
+      items: {
+        labelItems: {
+          component: 'items',
+          ref: 'components',
+          key: 'legend',
+          items: scatterPlotLabelsDefinition('legend.label', fontResolver, theme),
+        },
+      },
+    };
+  }
+
+  return Object.keys(items).length > 0 ? items : undefined;
 };
+
+const getStylingPanelDefinition = (bkgOptionsEnabled, flags, translator, theme) => ({
+  component: 'styling-panel',
+  chartTitle: 'Object.ScatterPlot',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  ref: 'components',
+  useGeneral: true,
+  useBackground: bkgOptionsEnabled,
+  items: getStylingItems(flags, translator, theme),
+});
 
 export default getStylingPanelDefinition;

--- a/src/hooks/use-models.js
+++ b/src/hooks/use-models.js
@@ -106,6 +106,7 @@ const useModels = ({ core, flags }) => {
     const extremumModel = createExtremumModel(layoutService, options.viewState);
 
     const dataHandler = createDataHandler({ layoutService, model, extremumModel });
+    const styleModel = createStyleModel({ layoutService, themeService, flags });
 
     const colorService = createColorService({
       actions,
@@ -120,6 +121,7 @@ const useModels = ({ core, flags }) => {
       picasso: picassoInstance,
       viewState,
       dataHandler,
+      styleModel,
     });
 
     let chartModel;
@@ -192,7 +194,6 @@ const useModels = ({ core, flags }) => {
     });
 
     const disclaimerModel = createDisclaimerModel({ layoutService });
-    const styleModel = createStyleModel({ layoutService, themeService, flags });
 
     selectionService.setLayout(layoutService.getLayout());
     setModels({

--- a/src/models/style-model/__tests__/index.spec.js
+++ b/src/models/style-model/__tests__/index.spec.js
@@ -87,10 +87,6 @@ describe('createStyleModel', () => {
     expect(create().query).to.have.all.keys(['axis', 'label', 'referenceLine', 'legend']);
   });
 
-  it('query should have only four keys', () => {
-    expect(Object.keys(create().query).length).to.equal(4);
-  });
-
   describe('legend', () => {
     it('should expose correct properties', () => {
       expect(create().query.legend).to.have.all.keys(['title', 'label']);

--- a/src/models/style-model/__tests__/index.spec.js
+++ b/src/models/style-model/__tests__/index.spec.js
@@ -47,6 +47,18 @@ describe('createStyleModel', () => {
           },
         },
       },
+      legend: {
+        title: {
+          fontFamily: 'Arial, sans-serif',
+          fontSize: '12',
+          color: 'green',
+        },
+        label: {
+          fontFamily: 'Comic Sans MS, cursive',
+          fontSize: '13',
+          color: 'blue',
+        },
+      },
     };
 
     themeService = { getStyles: sandbox.stub() };
@@ -72,7 +84,67 @@ describe('createStyleModel', () => {
   });
 
   it('query should have correct properties', () => {
-    expect(create().query).to.have.all.keys(['axis', 'label', 'referenceLine']);
+    expect(create().query).to.have.all.keys(['axis', 'label', 'referenceLine', 'legend']);
+  });
+
+  it('query should have only four keys', () => {
+    expect(Object.keys(create().query).length).to.equal(4);
+  });
+
+  describe('legend', () => {
+    it('should expose correct properties', () => {
+      expect(create().query.legend).to.have.all.keys(['title', 'label']);
+    });
+
+    describe('title', () => {
+      it('should expose correct properties', () => {
+        expect(create().query.legend.title).to.have.all.keys(['getStyle']);
+      });
+
+      describe('getStyle', () => {
+        it('should return theme style when no matching component', () => {
+          layoutService.getLayoutValue.withArgs('components', []).returns([]);
+          expect(create().query.legend.title.getStyle()).to.deep.equal(themeStyles.legend.title);
+        });
+
+        it('should return legend title component', () => {
+          component = {
+            key: 'legend',
+            legend: { title: { fontFamily: 'TheFont', fontSize: '1234', color: { color: 'tranquil-teal', index: 3 } } },
+          };
+          layoutService.getLayoutValue.withArgs('components', []).returns([component, { key: 'line', line: {} }]);
+          const { fontSize, fontFamily, color } = create().query.legend.title.getStyle();
+          expect(fontSize).to.equal('1234');
+          expect(fontFamily).to.equal('TheFont');
+          expect(color).to.equal('tranquil-teal');
+        });
+      });
+    });
+
+    describe('label', () => {
+      it('should expose correct properties', () => {
+        expect(create().query.legend.label).to.have.all.keys(['getStyle']);
+      });
+
+      describe('getStyle', () => {
+        it('should return theme style when no matching component', () => {
+          layoutService.getLayoutValue.withArgs('components', []).returns([]);
+          expect(create().query.legend.label.getStyle()).to.deep.equal(themeStyles.legend.label);
+        });
+
+        it('should return legend title component', () => {
+          component = {
+            key: 'legend',
+            legend: { label: { fontFamily: 'DuFont', fontSize: '14234', color: { color: 'tranquil-blue', index: 3 } } },
+          };
+          layoutService.getLayoutValue.withArgs('components', []).returns([component, { key: 'line', line: {} }]);
+          const { fontSize, fontFamily, color } = create().query.legend.label.getStyle();
+          expect(fontSize).to.equal('14234');
+          expect(fontFamily).to.equal('DuFont');
+          expect(color).to.equal('tranquil-blue');
+        });
+      });
+    });
   });
 
   describe('axis', () => {
@@ -94,13 +166,13 @@ describe('createStyleModel', () => {
         it('should return axis title component', () => {
           component = {
             key: 'axis',
-            axis: { title: { fontFamily: 'Arial, sans-serif', fontSize: '44', color: 'green' } },
+            axis: { title: { fontFamily: 'Arial, sans-serif', fontSize: '44', color: { color: 'greens', index: 3 } } },
           };
           layoutService.getLayoutValue.withArgs('components', []).returns([component, { key: 'line', line: {} }]);
           const { fontSize, fontFamily, color } = create().query.axis.title.getStyle();
           expect(fontSize).to.equal('44');
           expect(fontFamily).to.equal('Arial, sans-serif');
-          expect(color).to.equal('green');
+          expect(color).to.equal('greens');
         });
       });
     });
@@ -123,14 +195,14 @@ describe('createStyleModel', () => {
           component = {
             key: 'axis',
             axis: {
-              label: { name: { fontFamily: 'Arial, sans-serif', fontSize: '44', color: { color: 'yellow' } } },
+              label: { name: { fontFamily: 'Arials, sans-serif', fontSize: '444', color: { color: 'black' } } },
             },
           };
           layoutService.getLayoutValue.withArgs('components', []).returns([component, { key: 'line' }]);
           const { fontSize, fontFamily, fill } = create().query.axis.label.getStyle();
-          expect(fontSize).to.equal('44');
-          expect(fontFamily).to.equal('Arial, sans-serif');
-          expect(fill).to.equal('yellow');
+          expect(fontSize).to.equal('444');
+          expect(fontFamily).to.equal('Arials, sans-serif');
+          expect(fill).to.equal('black');
         });
       });
     });

--- a/src/models/style-model/index.js
+++ b/src/models/style-model/index.js
@@ -2,7 +2,7 @@ export default function createStyleModel({ layoutService, themeService, flags })
   const styles = themeService.getStyles();
 
   const overrides = (key) => {
-    const isEnabled = flags.isEnabled('CLIENT_IM_3050');
+    const isEnabled = flags.isEnabled('CLIENT_IM_3050') || flags.isEnabled('CLIENT_IM_3051');
     return isEnabled ? layoutService.getLayoutValue('components', [])?.find((c) => c.key === key) : undefined;
   };
 
@@ -38,6 +38,22 @@ export default function createStyleModel({ layoutService, themeService, flags })
         fontSize: overrides('label')?.label?.value?.fontSize ?? styles.label.value.fontSize,
         fontFamily: overrides('label')?.label?.value?.fontFamily ?? styles.label.value.fontFamily,
       }),
+    },
+    legend: {
+      title: {
+        getStyle: () => ({
+          fontFamily: overrides('legend')?.legend?.title?.fontFamily ?? styles.legend.title.fontFamily,
+          fontSize: overrides('legend')?.legend?.title?.fontSize ?? styles.legend.title.fontSize,
+          color: overrides('legend')?.legend?.title?.color?.color ?? styles.legend.title.color,
+        }),
+      },
+      label: {
+        getStyle: () => ({
+          fontFamily: overrides('legend')?.legend?.label?.fontFamily ?? styles.legend.label.fontFamily,
+          fontSize: overrides('legend')?.legend?.label?.fontSize ?? styles.legend.label.fontSize,
+          color: overrides('legend')?.legend?.label?.color?.color ?? styles.legend.label.color,
+        }),
+      },
     },
   };
 

--- a/src/qae/object-definition.js
+++ b/src/qae/object-definition.js
@@ -521,6 +521,7 @@ export default objectDefinition;
  * @property {axisStyle} axis
  * @property {labelStyle} label
  * @property {referenceLineStyle} referenceLine
+ * @property {legendStyle} legendStyle
  */
 
 /**
@@ -537,6 +538,12 @@ export default objectDefinition;
 /**
  * @typedef {object} referenceLineStyle
  * @property {labelNameStyle} label
+ */
+
+/**
+ * @typedef {object} legendStyle
+ * @property {fontStyle} title
+ * @property {fontStyle} label
  */
 
 /**

--- a/src/services/color-service/index.js
+++ b/src/services/color-service/index.js
@@ -15,6 +15,7 @@ export default function createService({
   picasso,
   viewState,
   dataHandler,
+  styleModel,
 }) {
   let colorService;
   const state = {
@@ -36,6 +37,7 @@ export default function createService({
       options,
       colorService,
       actions,
+      styleModel,
     });
 
     state.wrappedScales = scales;

--- a/src/services/color-service/legend/__tests__/index.spec.js
+++ b/src/services/color-service/legend/__tests__/index.spec.js
@@ -11,6 +11,7 @@ describe('legend', () => {
   let options;
   let colorService;
   let actions;
+  let styleModel;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -24,7 +25,8 @@ describe('legend', () => {
     options = { direction: 'rtl' };
     sandbox.stub(settings, 'default').returns('settings');
     actions = { interact: { enabled: sandbox.stub().returns(true) } };
-    create = () => createLegend({ viewState, chart, options, colorService, actions });
+    styleModel = { query: { legend: { title: { getStyle: () => {} }, label: { getStyle: () => {} } } } };
+    create = () => createLegend({ viewState, chart, options, colorService, actions, styleModel });
   });
 
   afterEach(() => {
@@ -40,6 +42,10 @@ describe('legend', () => {
         viewState: 'view-state',
         chart: 'chart',
         styleReference: 'object.scatterPlot',
+        styleOverrides: {
+          title: styleModel.query.legend.title.getStyle(),
+          label: styleModel.query.legend.label.getStyle(),
+        },
         rtl: true,
         settings: 'settings',
       },

--- a/src/services/color-service/legend/index.js
+++ b/src/services/color-service/legend/index.js
@@ -1,7 +1,7 @@
 import KEYS from '../../../constants/keys';
 import settings from './settings';
 
-export default function createLegend({ viewState, chart, options, colorService, actions }) {
+export default function createLegend({ viewState, chart, options, colorService, actions, styleModel }) {
   const rtl = options.direction === 'rtl';
 
   const config = {
@@ -10,6 +10,10 @@ export default function createLegend({ viewState, chart, options, colorService, 
     viewState,
     chart,
     styleReference: 'object.scatterPlot',
+    styleOverrides: {
+      title: styleModel.query.legend.title.getStyle(),
+      label: styleModel.query.legend.label.getStyle(),
+    },
     rtl,
     settings: settings({ colorService }),
   };


### PR DESCRIPTION
## Description

Adding the possibility of configure styling for the following properties for the scatter plot legend

- Legend title
- Legend labels

Flag is CLIENT_IM_3051

Properties added to the components array:
```
{
  "key": "legend",
  "legend": {
    "title": {
      "fontFamily": "Courier, monospace",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#ff5300" }
    },
    "label": {
      "fontFamily": "Didot, serif",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#00ff0e" }
    }
  }
}
```
