### PR TITLE
chore: bumping-qlik-chart-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prettier": "2.8.8",
     "pretty-quick": "3.1.3",
     "prop-types": "^15.8.1",
-    "qlik-chart-modules": "0.57.0",
+    "qlik-chart-modules": "0.59.0",
     "qlik-object-conversion": "0.16.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10713,10 +10713,10 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qlik-chart-modules@0.57.0:
-  version "0.57.0"
-  resolved "https://registry.yarnpkg.com/qlik-chart-modules/-/qlik-chart-modules-0.57.0.tgz#dd31a5f702c8d030693cd740ccace2e6de97464c"
-  integrity sha512-GYnOFKIKSZUeeEz1yLuNeReQ2D9OKJ9GATIpTdCJVvPwKGi9/kntsPI7YmMPZSnV3XnhkWSKkgc99RmfNJdHsw==
+qlik-chart-modules@0.59.0:
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/qlik-chart-modules/-/qlik-chart-modules-0.59.0.tgz#2bffe8ebdbef5dc0316907933c1061e2fe1bfac7"
+  integrity sha512-ErnAjpIugAUzXPnRS4l+rxQghmMjd67Q3FeFyWVWT2WCZDMjsOw4a3hSUIN3h5OOwtzSBmw3jxdDqL8DmTMDjw==
 
 qlik-modifiers@0.5.1:
   version "0.5.1"


### PR DESCRIPTION
Bumping qlik-chart-modules to latest version to get fontFamily property on chart specific fonts:
![Screenshot 2023-09-04 at 11 03 03](https://github.com/qlik-oss/sn-scatter-plot/assets/43105/6059ec05-7de5-4c22-99e7-56b3e3edb670)
