### PR TITLE
add translation for overview in footer of scatterplot

### DIFF
--- a/src/locale/all.json
+++ b/src/locale/all.json
@@ -718,5 +718,11 @@
       "zh-TW": "關閉套索選取",
       "ru-RU": "Выключить выбор лассо"
     }
+  },
+  "properties.compression.providingOverviewOf": {
+    "id": "properties.compression.providingOverviewOf",
+    "locale": {
+      "en-US": "Providing overview of {0} dimension values."
+    }
   }
 }


### PR DESCRIPTION
Overview footer is not getting localized when we render scatterplot in a new repo. (it works when we create chart in sheet view)

![Screen Shot 2023-10-19 at 10 03 50 AM](https://github.com/qlik-oss/dist-flow/assets/12648587/b8f84c44-3c62-45d9-93d2-150339ae6368)
