### PR TITLE
fix: problem with translations loading

### DIFF
--- a/src/locale/__tests__/index.spec.js
+++ b/src/locale/__tests__/index.spec.js
@@ -24,7 +24,7 @@ describe('autoRegister', () => {
   });
 
   it('should call translator.add if translated string is the same as its id', () => {
-    translator.get.returns('Object.Disclaimer.LimitedData');
+    translator.get.returns('properties.compression.providingOverviewOf');
     create();
     expect(translator.add).to.have.been.called;
   });

--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -2,7 +2,7 @@ import all from './all.json';
 
 export default function autoRegister(translator) {
   if (translator && translator.get && translator.add) {
-    const t = 'Object.Disclaimer.LimitedData';
+    const t = 'properties.compression.providingOverviewOf';
     const g = translator.get(t);
     // if translated string is different from its id
     // assume translations already exists for current locale


### PR DESCRIPTION
Use a translation key that is unique to the scatterplot to determine wether translations has been loaded or not.

It could happen, if used in the same context as another chart that had the same translation key among it's translations, that the translations for the scatter-plot were never loaded. This should solve that problem.