### PR TITLE
refactor: add default value for maxVisibleBubbles

### DIFF
--- a/nebula.config.js
+++ b/nebula.config.js
@@ -17,9 +17,6 @@ module.exports = {
   serve: {
     flags: {
       panZoom: true,
-      DATA_BINNING: true,
-      NUM_BUBBLES: true,
-      PROGRESSIVE_RENDERING: true,
       CLIENT_IM_3050: true,
     },
   },

--- a/src/data-handler/__tests__/data-fetcher.spec.js
+++ b/src/data-handler/__tests__/data-fetcher.spec.js
@@ -60,10 +60,9 @@ describe('createDataFetcher', () => {
     expect(someRejectFn).to.have.been.calledOnce;
   });
 
-  describe('layoutService.meta.isMaxVisibleBubblesEnabled = true', () => {
+  describe('maxVisibleBubbles', () => {
     beforeEach(() => {
       pages = [{ realDataPageBlabla: true, qNodes: [], qArea: { qWidth: 3 }, qMatrix: [1, 2], qTails: [10, 20] }];
-      layoutService.meta.isMaxVisibleBubblesEnabled = true;
       layoutService.meta.maxVisibleBubbles = 4000;
       layoutService.meta.size = { y: 3000 };
     });

--- a/src/data-handler/__tests__/data-fetcher.spec.js
+++ b/src/data-handler/__tests__/data-fetcher.spec.js
@@ -13,13 +13,16 @@ describe('createDataFetcher', () => {
     layoutService = {
       meta: {
         isSnapshot: false,
+        size: {
+          y: 1000,
+        },
       },
       getDataPages: sinon.stub().returns([{ snapshotData: true }]),
       setLayoutValue: sandbox.stub(),
       setDataPages: sandbox.stub(),
     };
 
-    pages = [{ realDataPageBlabla: true, qNodes: [] }];
+    pages = [{ realDataPageBlabla: true, qNodes: [], qMatrix: [], qArea: { qWidth: 4 }, qTails: {} }];
     model = {
       getHyperCubeData: sinon.stub().callsFake(async () => pages),
     };
@@ -45,12 +48,24 @@ describe('createDataFetcher', () => {
         qTop: 0,
         qLeft: 0,
         qWidth: 4,
-        qHeight: 2000,
+        qHeight: 2500,
       },
     ]);
-    expect(dataPages).to.eql(pages);
+
+    expect(dataPages).to.eql([
+      {
+        qArea: {
+          qHeight: 1000,
+          qLeft: 0,
+          qTop: 0,
+          qWidth: 4,
+        },
+        qMatrix: [],
+        qTails: {},
+      },
+    ]);
     expect(layoutService.setLayoutValue.withArgs('dataPages', undefined)).to.have.been.calledOnce;
-    expect(layoutService.setDataPages.withArgs(pages)).to.have.been.calledOnce;
+    expect(layoutService.setDataPages.withArgs(dataPages)).to.have.been.calledOnce;
   });
 
   it('should reject promise when trying to fetch the same data window twice in a row', async () => {

--- a/src/data-handler/__tests__/data-fetcher.spec.js
+++ b/src/data-handler/__tests__/data-fetcher.spec.js
@@ -16,6 +16,7 @@ describe('createDataFetcher', () => {
         size: {
           y: 1000,
         },
+        maxVisibleBubbles: 1000,
       },
       getDataPages: sinon.stub().returns([{ snapshotData: true }]),
       setLayoutValue: sandbox.stub(),

--- a/src/data-handler/data-fetcher.js
+++ b/src/data-handler/data-fetcher.js
@@ -1,4 +1,7 @@
 import KEYS from '../constants/keys';
+import NUMBERS from '../constants/numbers';
+
+const { DEFAULT_VISIBLE_BUBBLES } = NUMBERS;
 
 export default function createDataFetcher({ layoutService, model }) {
   let lastDataWindow;
@@ -10,7 +13,10 @@ export default function createDataFetcher({ layoutService, model }) {
       }
 
       const NUM_BUBBLES_PER_FETCH = 2500;
-      const NUM_BUBBLES = Math.min(layoutService.meta.maxVisibleBubbles, layoutService.meta.size.y || 0);
+      const NUM_BUBBLES = Math.min(
+        layoutService.meta.maxVisibleBubbles || DEFAULT_VISIBLE_BUBBLES,
+        layoutService.meta.size.y || 0
+      );
       const numFetches = Math.ceil(NUM_BUBBLES / NUM_BUBBLES_PER_FETCH);
       const dataRects = [];
       for (let i = 0; i < numFetches; i++) {

--- a/src/data-handler/data-fetcher.js
+++ b/src/data-handler/data-fetcher.js
@@ -1,7 +1,4 @@
 import KEYS from '../constants/keys';
-import NUMBERS from '../constants/numbers';
-
-const { DEFAULT_VISIBLE_BUBBLES } = NUMBERS;
 
 export default function createDataFetcher({ layoutService, model }) {
   let lastDataWindow;
@@ -13,10 +10,7 @@ export default function createDataFetcher({ layoutService, model }) {
       }
 
       const NUM_BUBBLES_PER_FETCH = 2500;
-      const NUM_BUBBLES = Math.min(
-        layoutService.meta.maxVisibleBubbles || DEFAULT_VISIBLE_BUBBLES,
-        layoutService.meta.size.y || 0
-      );
+      const NUM_BUBBLES = Math.min(layoutService.meta.maxVisibleBubbles, layoutService.meta.size.y || 0);
       const numFetches = Math.ceil(NUM_BUBBLES / NUM_BUBBLES_PER_FETCH);
       const dataRects = [];
       for (let i = 0; i < numFetches; i++) {

--- a/src/data-handler/data-fetcher.js
+++ b/src/data-handler/data-fetcher.js
@@ -9,65 +9,42 @@ export default function createDataFetcher({ layoutService, model }) {
         return Promise.resolve(layoutService.getDataPages());
       }
 
-      if (layoutService.meta.isMaxVisibleBubblesEnabled) {
-        const NUM_BUBBLES_PER_FETCH = 2500;
-        const NUM_BUBBLES = Math.min(layoutService.meta.maxVisibleBubbles, layoutService.meta.size.y || 0);
-        const numFetches = Math.ceil(NUM_BUBBLES / NUM_BUBBLES_PER_FETCH);
-        const dataRects = [];
-        for (let i = 0; i < numFetches; i++) {
-          dataRects[i] = {
-            qTop: i * NUM_BUBBLES_PER_FETCH,
-            qLeft: 0,
-            qWidth: 4,
-            qHeight: NUM_BUBBLES_PER_FETCH,
-          };
-        }
-
-        // Do not fetch same data window twice in a row (important for performance)
-        const dataWindow = JSON.stringify(dataRects[0]);
-        if (lastDataWindow === dataWindow) {
-          return Promise.reject(KEYS.REJECTION_TOKEN);
-        }
-
-        lastDataWindow = dataWindow;
-
-        const queriesPromises = dataRects.map((dataRect) => model.getHyperCubeData('/qHyperCubeDef', [dataRect]));
-        return Promise.all(queriesPromises).then((pagesArray) => {
-          const pages = [
-            {
-              qArea: {
-                qLeft: 0,
-                qTop: 0,
-                qWidth: pagesArray[pagesArray.length - 1][0].qArea.qWidth,
-                qHeight: NUM_BUBBLES,
-              },
-              qMatrix: [],
-              qTails: pagesArray[0][0].qTails,
-            },
-          ];
-          pagesArray.forEach((p) => pages[0].qMatrix.push(...p[0].qMatrix));
-          layoutService.setLayoutValue('dataPages', undefined);
-          layoutService.setDataPages(pages);
-          return pages;
-        });
+      const NUM_BUBBLES_PER_FETCH = 2500;
+      const NUM_BUBBLES = Math.min(layoutService.meta.maxVisibleBubbles, layoutService.meta.size.y || 0);
+      const numFetches = Math.ceil(NUM_BUBBLES / NUM_BUBBLES_PER_FETCH);
+      const dataRects = [];
+      for (let i = 0; i < numFetches; i++) {
+        dataRects[i] = {
+          qTop: i * NUM_BUBBLES_PER_FETCH,
+          qLeft: 0,
+          qWidth: 4,
+          qHeight: NUM_BUBBLES_PER_FETCH,
+        };
       }
 
-      const dataRect = {
-        qTop: 0,
-        qLeft: 0,
-        qWidth: 4,
-        qHeight: 2000,
-      };
-
       // Do not fetch same data window twice in a row (important for performance)
-      const dataWindow = JSON.stringify(dataRect);
+      const dataWindow = JSON.stringify(dataRects[0]);
       if (lastDataWindow === dataWindow) {
         return Promise.reject(KEYS.REJECTION_TOKEN);
       }
 
       lastDataWindow = dataWindow;
 
-      return model.getHyperCubeData('/qHyperCubeDef', [dataRect]).then((pages) => {
+      const queriesPromises = dataRects.map((dataRect) => model.getHyperCubeData('/qHyperCubeDef', [dataRect]));
+      return Promise.all(queriesPromises).then((pagesArray) => {
+        const pages = [
+          {
+            qArea: {
+              qLeft: 0,
+              qTop: 0,
+              qWidth: pagesArray[pagesArray.length - 1][0].qArea.qWidth,
+              qHeight: NUM_BUBBLES,
+            },
+            qMatrix: [],
+            qTails: pagesArray[0][0].qTails,
+          },
+        ];
+        pagesArray.forEach((p) => pages[0].qMatrix.push(...p[0].qMatrix));
         layoutService.setLayoutValue('dataPages', undefined);
         layoutService.setDataPages(pages);
         return pages;

--- a/src/ext/explore-definition/index.js
+++ b/src/ext/explore-definition/index.js
@@ -5,9 +5,7 @@ import colorModeOptions from './color-mode-options';
 import showColorScheme from './show-color-scheme';
 import showPersistentColors from './show-persistent-colors';
 
-export default function exploreDefinition(env) {
-  const { flags } = env;
-
+export default function exploreDefinition() {
   return {
     type: 'items',
     component: 'accordion',
@@ -85,7 +83,7 @@ export default function exploreDefinition(env) {
             max: 8,
             step: 1,
             show(data, layout) {
-              return showCompressionResolution(layout, flags.isEnabled('NUM_BUBBLES') ? data : undefined);
+              return showCompressionResolution(layout, data);
             },
           },
         },

--- a/src/ext/property-definition/index.js
+++ b/src/ext/property-definition/index.js
@@ -281,20 +281,18 @@ export default function propertyDefinition(env) {
             step: 1,
             defaultValue: 5,
             show(data, handler) {
-              return showCompressionResolution(handler.layout, flags.isEnabled('NUM_BUBBLES') ? data : undefined);
+              return showCompressionResolution(handler.layout, data);
             },
           },
-          maxVisibleBubbles: !flags.isEnabled('NUM_BUBBLES')
-            ? undefined
-            : {
-                type: 'integer',
-                expression: 'optional',
-                ref: 'maxVisibleBubbles',
-                translation: 'properties.dataPoints.maxVisibleBubbles',
-                defaultValue: DEFAULT_VISIBLE_BUBBLES,
-                min: MAX_NR_SCATTER,
-                max: MAX_VISIBLE_BUBBLES,
-              },
+          maxVisibleBubbles: {
+            type: 'integer',
+            expression: 'optional',
+            ref: 'maxVisibleBubbles',
+            translation: 'properties.dataPoints.maxVisibleBubbles',
+            defaultValue: DEFAULT_VISIBLE_BUBBLES,
+            min: MAX_NR_SCATTER,
+            max: MAX_VISIBLE_BUBBLES,
+          },
           gridLines: {
             type: 'items',
             snapshot: {

--- a/src/picasso-definition/brush/__tests__/point-brush.spec.js
+++ b/src/picasso-definition/brush/__tests__/point-brush.spec.js
@@ -23,7 +23,6 @@ describe('createPointBrush', () => {
         isBigData: false,
         isLargeNumDataPoints: false,
         hasSizeMeasure: true,
-        isMaxVisibleBubblesEnabled: true,
       },
     };
     chartModel = { command: { brush: sandbox.spy() } };
@@ -210,10 +209,5 @@ describe('createPointBrush', () => {
     create().customRender({ render, nodes });
     expect(render).to.not.have.been.called;
     expect(chartModel.command.brush).to.have.been.calledWithExactly({ render, nodes });
-  });
-
-  it('should not have customRender if isMaxVisibleBubblesEnabled = false', () => {
-    layoutService.meta.isMaxVisibleBubblesEnabled = false;
-    expect(typeof create().customRender).to.equal('undefined');
   });
 });

--- a/src/picasso-definition/brush/point-brush.js
+++ b/src/picasso-definition/brush/point-brush.js
@@ -48,14 +48,12 @@ export default function createBrush({ layoutService, largeDataService, chartMode
       }
       return inactiveNodes.concat(activeNodes);
     },
-    customRender: !layoutService.meta.isMaxVisibleBubblesEnabled
-      ? undefined
-      : ({ render, nodes }) => {
-          if (largeDataService.shouldUseProgressive()) {
-            chartModel.command.brush({ render, nodes });
-          } else {
-            render(nodes);
-          }
-        },
+    customRender: ({ render, nodes }) => {
+      if (largeDataService.shouldUseProgressive()) {
+        chartModel.command.brush({ render, nodes });
+      } else {
+        render(nodes);
+      }
+    },
   };
 }

--- a/src/picasso-definition/components/mini-chart/__tests__/background-window.spec.js
+++ b/src/picasso-definition/components/mini-chart/__tests__/background-window.spec.js
@@ -6,7 +6,6 @@ describe('createMiniChartBackgroundWindow', () => {
   let sandbox;
   let create;
   let chartModel;
-  let flags;
   let viewHandler;
 
   beforeEach(() => {
@@ -24,8 +23,6 @@ describe('createMiniChartBackgroundWindow', () => {
         miniChartEnabled: sandbox.stub(),
       },
     };
-    flags = { isEnabled: sandbox.stub() };
-    flags.isEnabled.withArgs('DATA_BINNING').returns(true);
     create = () => createMiniChartBackgroundWindow(chartModel);
   });
 

--- a/src/picasso-definition/components/mini-chart/__tests__/mini-points.spec.js
+++ b/src/picasso-definition/components/mini-chart/__tests__/mini-points.spec.js
@@ -6,7 +6,6 @@ describe('createMiniChartPoints', () => {
   let sandbox;
   let create;
   let chartModel;
-  let flags;
   let viewHandler;
   let dataHandler;
   let d;
@@ -36,8 +35,6 @@ describe('createMiniChartPoints', () => {
         miniChartEnabled: sandbox.stub(),
       },
     };
-    flags = { isEnabled: sandbox.stub() };
-    flags.isEnabled.withArgs('DATA_BINNING').returns(true);
     d = { datum: { value: { qText: [8, 12, 12, 8], qNum: 3 } }, scale: sandbox.stub() };
     d.scale.withArgs(3).returns(0.3);
     rtl = false;

--- a/src/picasso-definition/components/mini-chart/__tests__/navigation-window.spec.js
+++ b/src/picasso-definition/components/mini-chart/__tests__/navigation-window.spec.js
@@ -6,7 +6,6 @@ describe('createMiniChartNavigationWindow', () => {
   let sandbox;
   let create;
   let chartModel;
-  let flags;
   let viewHandler;
 
   beforeEach(() => {
@@ -24,8 +23,6 @@ describe('createMiniChartNavigationWindow', () => {
       getDataView: sandbox.stub().returns({ xAxisMin: 10, xAxisMax: 30, yAxisMin: 5, yAxisMax: 15 }),
     };
     chartModel = { query: { getViewHandler: sandbox.stub().returns(viewHandler), miniChartEnabled: sandbox.stub() } };
-    flags = { isEnabled: sandbox.stub() };
-    flags.isEnabled.withArgs('DATA_BINNING').returns(true);
     create = () => createMiniChartNavigationWindow(chartModel);
   });
 

--- a/src/picasso-definition/components/point-labels/index.js
+++ b/src/picasso-definition/components/point-labels/index.js
@@ -31,9 +31,7 @@ export default function createPointLabels({ models, animationsEnabled }) {
     settings: {
       label: (node) => node.data.label,
       mode: labels.mode,
-      maxVisibleBubblesForLabeling: layoutService.meta.isMaxVisibleBubblesEnabled
-        ? NUMBERS.LARGE_NUM_DATA_POINTS
-        : undefined,
+      maxVisibleBubblesForLabeling: NUMBERS.LARGE_NUM_DATA_POINTS,
       // debugMode: true,
     },
     style: {

--- a/src/picasso-definition/components/point/__tests__/index.spec.js
+++ b/src/picasso-definition/components/point/__tests__/index.spec.js
@@ -194,13 +194,7 @@ describe('point', () => {
       expect(create().rendererSettings.canvasBufferSize(compRect)).to.deep.equal({ width: 300, height: 250 });
     });
 
-    it('should not have progressive if layoutService.meta.isProgressiveEnabled = false', () => {
-      layoutService.meta.isProgressiveEnabled = false;
-      expect(create().rendererSettings.progressive).to.equal(undefined);
-    });
-
-    it('should have progressive if layoutService.meta.isProgressiveEnabled = true', () => {
-      layoutService.meta.isProgressiveEnabled = true;
+    it('should have progressive rendering', () => {
       chartModel.query.getMeta.returns({ progressive: 123 });
       const progressive = create().rendererSettings.progressive();
       expect(progressive).to.equal(123);

--- a/src/picasso-definition/components/point/index.js
+++ b/src/picasso-definition/components/point/index.js
@@ -56,12 +56,10 @@ export default function createPoint({ models, chart, animationsEnabled }) {
         width: rect.computedPhysical.width + 100,
         height: rect.computedPhysical.height + 100,
       }),
-      progressive: layoutService.meta.isProgressiveEnabled
-        ? () => {
-            const meta = chartModel.query.getMeta();
-            return meta.progressive;
-          }
-        : undefined,
+      progressive: () => {
+        const meta = chartModel.query.getMeta();
+        return meta.progressive;
+      },
     },
   };
 }

--- a/src/picasso-definition/interactions/is-zoom-by-image.js
+++ b/src/picasso-definition/interactions/is-zoom-by-image.js
@@ -1,7 +1,6 @@
 const isZoomByImage = (models, threshold = 0) => {
   const { layoutService, chartModel } = models;
   const { meta } = layoutService;
-  if (!meta.isMaxVisibleBubblesEnabled) return false;
   if (meta.isBigData) {
     const dataPages = layoutService.getDataPages();
     if (dataPages.length) {

--- a/src/qae/__tests__/object-definition.spec.js
+++ b/src/qae/__tests__/object-definition.spec.js
@@ -21,6 +21,7 @@ describe('object-definition', () => {
       'labels',
       'gridLine',
       'legend',
+      'maxVisibleBubbles',
       'navigation',
       'qHyperCubeDef',
       'refLine',

--- a/src/qae/object-definition.js
+++ b/src/qae/object-definition.js
@@ -251,6 +251,13 @@ const objectDefinition = () => {
       showTitle: true,
     },
     /**
+     * Set the maximum number of visible bubbles for the chart.
+     * Max is 50000 and min is 1000.
+     * @type {number}
+     * @default
+     */
+    maxVisibleBubbles: 2500,
+    /**
      * Show navigation UI.
      * @type {boolean}
      * @default

--- a/src/services/layout-service/__tests__/meta.spec.js
+++ b/src/services/layout-service/__tests__/meta.spec.js
@@ -52,7 +52,7 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isLargeNumDataPoints: false,
+      isLargeNumDataPoints: true,
       maxVisibleBubbles: 100,
       largeNumDataPoints: 100,
       numDataPoints: 15000,

--- a/src/services/layout-service/__tests__/meta.spec.js
+++ b/src/services/layout-service/__tests__/meta.spec.js
@@ -19,8 +19,6 @@ describe('meta', () => {
       .stub(NUMBERS, 'default')
       .value({ MAX_NR_SCATTER: 100, LARGE_NUM_DATA_POINTS: 500, MAX_VISIBLE_BUBBLES: 10000 });
     flags = { isEnabled: sandbox.stub() };
-    flags.isEnabled.withArgs('NUM_BUBBLES').returns(false);
-    flags.isEnabled.withArgs('PROGRESSIVE_RENDERING').returns(false);
     create = () => createMeta(flags, qUnsupportedFeatures);
   });
 
@@ -37,8 +35,6 @@ describe('meta', () => {
       isBigData: true,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: false,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 100,
       largeNumDataPoints: 100,
@@ -56,8 +52,6 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: false,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 100,
       largeNumDataPoints: 100,
@@ -77,8 +71,6 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: false,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 300,
       largeNumDataPoints: 300,
@@ -97,8 +89,6 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 300,
       largeNumDataPoints: 300,
@@ -117,8 +107,6 @@ describe('meta', () => {
       isBigData: true,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 300,
       largeNumDataPoints: 300,
@@ -137,8 +125,6 @@ describe('meta', () => {
       isBigData: true,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 300,
       largeNumDataPoints: 300,
@@ -157,8 +143,6 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 600,
       largeNumDataPoints: 500,
@@ -177,8 +161,6 @@ describe('meta', () => {
       isBigData: false,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: true,
       maxVisibleBubbles: 600,
       largeNumDataPoints: 500,
@@ -197,8 +179,6 @@ describe('meta', () => {
       isBigData: true,
       isContinuous: true,
       isRangeSelectionsSupported: true,
-      isMaxVisibleBubblesEnabled: true,
-      isProgressiveEnabled: false,
       isLargeNumDataPoints: false,
       maxVisibleBubbles: 600,
       largeNumDataPoints: 500,

--- a/src/services/layout-service/meta.js
+++ b/src/services/layout-service/meta.js
@@ -7,16 +7,14 @@ export default function createLayoutServiceMetaFn(flags, qUnsupportedFeatures) {
     const hasSizeMeasure = !!getValue(layout.qHyperCube, 'qMeasureInfo.2');
     const qcy = getValue(layout.qHyperCube, 'qSize.qcy');
     const isBinningSupported = !qUnsupportedFeatures?.some((f) => f === 'binningData');
-    const isMaxVisibleBubblesEnabled = flags.isEnabled('NUM_BUBBLES');
-    const isProgressiveEnabled = flags.isEnabled('PROGRESSIVE_RENDERING');
     const maxVisibleBubbles =
-      !isMaxVisibleBubblesEnabled || layout.maxVisibleBubbles === undefined || layout.maxVisibleBubbles <= 0
+      layout.maxVisibleBubbles === undefined || layout.maxVisibleBubbles <= 0
         ? NUMBERS.MAX_NR_SCATTER
         : Math.min(NUMBERS.MAX_VISIBLE_BUBBLES, Math.max(NUMBERS.MAX_NR_SCATTER, Math.ceil(layout.maxVisibleBubbles)));
     const isBigData = isBinningSupported && qcy > maxVisibleBubbles;
     const isRangeSelectionsSupported = !qUnsupportedFeatures?.some((f) => f === 'rangeSelections');
     const largeNumDataPoints = Math.min(NUMBERS.LARGE_NUM_DATA_POINTS, maxVisibleBubbles);
-    const isLargeNumDataPoints = !isBigData && isMaxVisibleBubblesEnabled && qcy > largeNumDataPoints;
+    const isLargeNumDataPoints = !isBigData && qcy > largeNumDataPoints;
 
     return {
       isSnapshot,
@@ -24,8 +22,6 @@ export default function createLayoutServiceMetaFn(flags, qUnsupportedFeatures) {
       isBigData,
       isContinuous: true,
       isRangeSelectionsSupported,
-      isMaxVisibleBubblesEnabled,
-      isProgressiveEnabled,
       isLargeNumDataPoints,
       maxVisibleBubbles,
       largeNumDataPoints,

--- a/src/utils/__tests__/is-progressive-allowed.spec.js
+++ b/src/utils/__tests__/is-progressive-allowed.spec.js
@@ -15,40 +15,30 @@ describe('isProgressiveAllowed', () => {
     sandbox.restore();
   });
 
-  it('should return false if isProgressiveEnabled = false', () => {
-    layoutService.meta.isProgressiveEnabled = false;
-    expect(isProgressiveEnabled(layoutService)).to.equal(false);
-  });
-
-  it('should return false if isProgressiveEnabled = true, isBigData = true && getNumPointsInBigData(layoutService) < largeNumDataPoints', () => {
-    layoutService.meta.isProgressiveEnabled = true;
+  it('should return false if isBigData = true && getNumPointsInBigData(layoutService) < largeNumDataPoints', () => {
     layoutService.meta.isBigData = true;
     expect(isProgressiveEnabled(layoutService)).to.equal(false);
   });
 
-  it('should return false if isProgressiveEnabled = true, isBigData = true && getNumPointsInBigData(layoutService) = largeNumDataPoints', () => {
-    layoutService.meta.isProgressiveEnabled = true;
+  it('should return false if isBigData = true && getNumPointsInBigData(layoutService) = largeNumDataPoints', () => {
     layoutService.meta.isBigData = true;
     layoutService.meta.largeNumDataPoints = 10;
     expect(isProgressiveEnabled(layoutService)).to.equal(false);
   });
 
-  it('should return true if isProgressiveEnabled = true, isBigData = true && getNumPointsInBigData(layoutService) > largeNumDataPoints', () => {
-    layoutService.meta.isProgressiveEnabled = true;
+  it('should return true if isBigData = true && getNumPointsInBigData(layoutService) > largeNumDataPoints', () => {
     layoutService.meta.isBigData = true;
     layoutService.meta.largeNumDataPoints = 5;
     expect(isProgressiveEnabled(layoutService)).to.equal(true);
   });
 
-  it('should return true if isProgressiveEnabled = true, isBigData = false && isLargeNumDataPoints = true', () => {
-    layoutService.meta.isProgressiveEnabled = true;
+  it('should return true if isBigData = false && isLargeNumDataPoints = true', () => {
     layoutService.meta.isBigData = false;
     layoutService.meta.isLargeNumDataPoints = true;
     expect(isProgressiveEnabled(layoutService)).to.equal(true);
   });
 
-  it('should return false if isProgressiveEnabled = true, isBigData = false && isLargeNumDataPoints = false', () => {
-    layoutService.meta.isProgressiveEnabled = true;
+  it('should return false if isBigData = false && isLargeNumDataPoints = false', () => {
     layoutService.meta.isBigData = false;
     layoutService.meta.isLargeNumDataPoints = false;
     expect(isProgressiveEnabled(layoutService)).to.equal(false);

--- a/src/utils/is-progressive-allowed.js
+++ b/src/utils/is-progressive-allowed.js
@@ -1,8 +1,7 @@
 import getNumPointsInBigData from './get-num-points-in-big-data';
 
 const isProgressiveAllowed = (layoutService) => {
-  const { isProgressiveEnabled, isBigData, largeNumDataPoints, isLargeNumDataPoints } = layoutService.meta;
-  if (!isProgressiveEnabled) return false;
+  const { isBigData, largeNumDataPoints, isLargeNumDataPoints } = layoutService.meta;
   if (isBigData) {
     return getNumPointsInBigData(layoutService) > largeNumDataPoints;
   }


### PR DESCRIPTION
Makes sure maxVisibleBubbles works properly even when the chart is rendered outside the sense-client.
Includes property in Api spec.
Adds maxVisibleBubbles: 2500 in initialProperties for newly created objects.
Removes the checks for the feature flag `NUM_BUBBLES` which is enabled everywhere anyway.
Also removes the checks for the `PROGRESSIVE_RENDERING` flag which has also been enabled everywhere for a while.

Info: max visible bubbles is 50000

Relates to #429 